### PR TITLE
Feat/v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Author: Rwx-G
 
 ## Unreleased
 
-## [1.0.1] - 2026-04-10
+## [1.1.0] - 2026-04-10
 
 ### Added
 
@@ -19,6 +19,7 @@ Author: Rwx-G
 - 12 new WAF rules (49 total): SQLi auth bypass, info schema recon, encoding evasion, NoSQL injection (MongoDB), XSS eval/base64, backup file access, PowerShell/Windows commands, HTTP request smuggling, scanner detection, PHP/Java deserialization, HTTP method abuse
 - X-Request-Id header: unique request identifier generated per request, propagated to backends and logged in access logs for end-to-end tracing
 - Circuit breaker: per-backend failure tracking that removes backends from rotation after 5 consecutive errors (5xx or connection failures), with 10s cooldown and half-open probe before recovery
+- Sticky sessions: cookie-based session affinity per route. When enabled, a `LORICA_SRV` cookie containing the backend ID is set on first request. Subsequent requests are routed to the same backend. Falls back to normal load balancing if the backend is down
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Author: Rwx-G
 - SLA breach notifications not firing in worker mode: supervisor now checks thresholds on every flush cycle regardless of local data, reading SLA metrics flushed by workers
 - Access logs: disabling auto-refresh/live toggle did not disconnect WebSocket, choice not persisted across page reloads
 - IP blocklist WAF events showing `-` as route when request has no Host header: now falls back to URI authority (IP:port)
+- Security page: missing category labels (SSRF, XXE, SSTI, Log4Shell, IP Blocklist, Prototype Pollution) and event filter options
 
 ## [1.0.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Author: Rwx-G
 - Global WAF whitelist IPs in Settings: IPs or CIDRs that bypass WAF evaluation, rate limiting, IP blocklist, and auto-ban entirely. Prevents operators from being auto-banned by false positives (e.g. CMS body content triggering path traversal rules)
 - CLI `lorica unban <IP> --password <PASSWORD>` command for emergency IP removal when locked out of the dashboard
 - Access logs: configurable entry limit (100/500/1K/5K/10K) and "X of Y entries" total count display
+- 12 new WAF rules (49 total): SQLi auth bypass, info schema recon, encoding evasion, NoSQL injection (MongoDB), XSS eval/base64, backup file access, PowerShell/Windows commands, HTTP request smuggling, scanner detection, PHP/Java deserialization, HTTP method abuse
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,5 +185,5 @@ Author: Rwx-G
 
 - Windows support removed from forked Pingora crates (Linux-only)
 
-[1.0.1]: https://github.com/Rwx-G/Lorica/releases/tag/v1.0.1
+[1.1.0]: https://github.com/Rwx-G/Lorica/releases/tag/v1.1.0
 [1.0.0]: https://github.com/Rwx-G/Lorica/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Author: Rwx-G
 
 - Duplicate access log entries in worker mode: workers now persist logs directly, supervisor only pushes to in-memory buffer for WebSocket streaming
 - WAF body scanning false positives: path traversal (930xxx) and protocol violation (920xxx) rules are no longer applied to request bodies, preventing false positives on CMS content containing `..\ ` or similar text
-- SLA metrics polluted by proxy-level rejections: WAF blocks, bans, rate limits, and return_status responses are excluded from SLA latency percentiles and uptime calculations
+- SLA metrics polluted by proxy-level rejections and connection errors: WAF blocks, bans, rate limits, return_status responses, and upstream/downstream errors (resets, timeouts) are excluded from SLA latency percentiles
 - SLA breach notifications not firing in worker mode: supervisor now checks thresholds on every flush cycle regardless of local data, reading SLA metrics flushed by workers
 - Access logs: disabling auto-refresh/live toggle did not disconnect WebSocket, choice not persisted across page reloads
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Author: Rwx-G
 - Client H2 disconnects ("not a result of an error") no longer shown as errors in access logs - status 0 is sufficient
 - TCP keepalive on upstream connections (idle 15s, interval 5s, 3 probes) to detect stale/half-closed pooled connections before reuse
 - Upstream idle connection timeout (60s) evicts stale connections from the pool
+- Upstream keepalive pool auto-sizing at startup: 128 for <= 15 backends, scales to 8 per backend up to 1024 max
 
 ## [1.0.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Author: Rwx-G
 - Access logs: disabling auto-refresh/live toggle did not disconnect WebSocket, choice not persisted across page reloads
 - IP blocklist WAF events showing `-` as route when request has no Host header: now falls back to URI authority (IP:port)
 - Security page: missing category labels (SSRF, XXE, SSTI, Log4Shell, IP Blocklist, Prototype Pollution) and event filter options
+- Client H2 disconnects ("not a result of an error") no longer shown as errors in access logs - status 0 is sufficient
 
 ## [1.0.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Author: Rwx-G
 - IP blocklist WAF events showing `-` as route when request has no Host header: now falls back to URI authority (IP:port)
 - Security page: missing category labels (SSRF, XXE, SSTI, Log4Shell, IP Blocklist, Prototype Pollution) and event filter options
 - Client H2 disconnects ("not a result of an error") no longer shown as errors in access logs - status 0 is sufficient
+- TCP keepalive on upstream connections (idle 15s, interval 5s, 3 probes) to detect stale/half-closed pooled connections before reuse
+- Upstream idle connection timeout (60s) evicts stale connections from the pool
 
 ## [1.0.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Author: Rwx-G
 - Access logs: configurable entry limit (100/500/1K/5K/10K) and "X of Y entries" total count display
 - 12 new WAF rules (49 total): SQLi auth bypass, info schema recon, encoding evasion, NoSQL injection (MongoDB), XSS eval/base64, backup file access, PowerShell/Windows commands, HTTP request smuggling, scanner detection, PHP/Java deserialization, HTTP method abuse
 - X-Request-Id header: unique request identifier generated per request, propagated to backends and logged in access logs for end-to-end tracing
+- Circuit breaker: per-backend failure tracking that removes backends from rotation after 5 consecutive errors (5xx or connection failures), with 10s cooldown and half-open probe before recovery
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Author: Rwx-G
 
+## Unreleased
+
+## [1.0.1] - 2026-04-10
+
+### Added
+
+- Global WAF whitelist IPs in Settings: IPs or CIDRs that bypass WAF evaluation, rate limiting, IP blocklist, and auto-ban entirely. Prevents operators from being auto-banned by false positives (e.g. CMS body content triggering path traversal rules)
+- CLI `lorica unban <IP> --password <PASSWORD>` command for emergency IP removal when locked out of the dashboard
+- Access logs: configurable entry limit (100/500/1K/5K/10K) and "X of Y entries" total count display
+
+### Fixed
+
+- Duplicate access log entries in worker mode: workers now persist logs directly, supervisor only pushes to in-memory buffer for WebSocket streaming
+- WAF body scanning false positives: path traversal (930xxx) and protocol violation (920xxx) rules are no longer applied to request bodies, preventing false positives on CMS content containing `..\ ` or similar text
+- SLA metrics polluted by proxy-level rejections: WAF blocks, bans, rate limits, and return_status responses are excluded from SLA latency percentiles and uptime calculations
+- SLA breach notifications not firing in worker mode: supervisor now checks thresholds on every flush cycle regardless of local data, reading SLA metrics flushed by workers
+- Access logs: disabling auto-refresh/live toggle did not disconnect WebSocket, choice not persisted across page reloads
+
 ## [1.0.0] - 2026-04-09
 
 ### Added
@@ -157,4 +175,5 @@ Author: Rwx-G
 
 - Windows support removed from forked Pingora crates (Linux-only)
 
+[1.0.1]: https://github.com/Rwx-G/Lorica/releases/tag/v1.0.1
 [1.0.0]: https://github.com/Rwx-G/Lorica/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Author: Rwx-G
 - CLI `lorica unban <IP> --password <PASSWORD>` command for emergency IP removal when locked out of the dashboard
 - Access logs: configurable entry limit (100/500/1K/5K/10K) and "X of Y entries" total count display
 - 12 new WAF rules (49 total): SQLi auth bypass, info schema recon, encoding evasion, NoSQL injection (MongoDB), XSS eval/base64, backup file access, PowerShell/Windows commands, HTTP request smuggling, scanner detection, PHP/Java deserialization, HTTP method abuse
+- X-Request-Id header: unique request identifier generated per request, propagated to backends and logged in access logs for end-to-end tracing
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Author: Rwx-G
 - SLA metrics polluted by proxy-level rejections and connection errors: WAF blocks, bans, rate limits, return_status responses, and upstream/downstream errors (resets, timeouts) are excluded from SLA latency percentiles
 - SLA breach notifications not firing in worker mode: supervisor now checks thresholds on every flush cycle regardless of local data, reading SLA metrics flushed by workers
 - Access logs: disabling auto-refresh/live toggle did not disconnect WebSocket, choice not persisted across page reloads
+- IP blocklist WAF events showing `-` as route when request has no Host header: now falls back to URI authority (IP:port)
 
 ## [1.0.0] - 2026-04-09
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/version-1.0.1-brightgreen.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.1.0-brightgreen.svg" alt="Version">
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Platform-Linux-0078D6.svg" alt="Platform">
   <img src="https://img.shields.io/badge/Lorica%20Tests-582-brightgreen.svg" alt="Lorica Tests">

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Built on [Cloudflare Pingora](https://github.com/cloudflare/pingora), the engine
 
 ### :lock: Security
 
-- **WAF engine** - 39 OWASP CRS-inspired rules (SQLi, XSS, path traversal, command injection, SSRF, Log4Shell, XXE, CRLF)
+- **WAF engine** - 49 OWASP CRS-inspired rules (SQLi, XSS, path traversal, command injection, SSRF, Log4Shell, XXE, CRLF)
 - **IP blocklist** - auto-fetched from Data-Shield IPv4 Blocklist (~80,000 entries, O(1) lookup, updated every 6h)
 - **Rate limiting** - per-route, per-client-IP with configurable RPS and burst tolerance
 - **Auto-ban** - IPs that repeatedly exceed rate limits are banned automatically (configurable threshold and duration)
@@ -160,7 +160,7 @@ The dashboard ships inside the binary and is served on the management port (defa
 
 <p align="center">
   <img src="docs/screenshots/security.png" alt="Security - WAF Rules" width="100%">
-  <br><em>39 WAF rules with per-rule toggle, covering SQLi, XSS, SSRF, Log4Shell, XXE, and more</em>
+  <br><em>49 WAF rules with per-rule toggle, covering SQLi, XSS, SSRF, Log4Shell, XXE, and more</em>
 </p>
 
 <p align="center">
@@ -174,7 +174,7 @@ The dashboard ships inside the binary and is served on the management port (defa
 - **Routes** - create/edit routes with host matching, path prefixes, load balancing, WAF mode, rate limits, caching, timeouts, security headers, CORS, and 25 other per-route settings
 - **Backends** - manage backend addresses, weights, health check type (TCP/HTTP), TLS upstream, active connections
 - **Certificates** - upload PEM certificates, view expiry dates, provision via ACME/Let's Encrypt (HTTP-01, DNS-01)
-- **Security** - WAF event table with category filtering, 39 rule toggles, IP ban list with unban button
+- **Security** - WAF event table with category filtering, 49 rule toggles, IP ban list with unban button
 - **SLA** - per-route passive/active SLA side-by-side, latency percentile tables, config editor, CSV/JSON export
 - **Load Tests** - test config management with clone, one-click execution, real-time SSE progress panel, historical results
 - **Active Probes** - CRUD for synthetic health probes with route selection, HTTP method/path/status/interval/timeout

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/version-1.0.0-brightgreen.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.0.1-brightgreen.svg" alt="Version">
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Platform-Linux-0078D6.svg" alt="Platform">
   <img src="https://img.shields.io/badge/Lorica%20Tests-582-brightgreen.svg" alt="Lorica Tests">

--- a/dist/rpm/lorica.spec
+++ b/dist/rpm/lorica.spec
@@ -1,5 +1,5 @@
 Name:           lorica
-Version:        1.0.0
+Version:        1.0.1
 Release:        1%{?dist}
 Summary:        Modern reverse proxy with built-in dashboard
 License:        Apache-2.0

--- a/dist/rpm/lorica.spec
+++ b/dist/rpm/lorica.spec
@@ -1,5 +1,5 @@
 Name:           lorica
-Version:        1.0.1
+Version:        1.1.0
 Release:        1%{?dist}
 Summary:        Modern reverse proxy with built-in dashboard
 License:        Apache-2.0

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,8 +4,7 @@
 
 | # | Feature | Complexity | Type | Notes |
 |---|---------|-----------|------|-------|
-| 1 | Sticky Sessions (cookie-based) | Low | Table-stakes | Inject Set-Cookie with backend ID, lookup on next request. Essential for stateful apps (PHP sessions, e-commerce). All major proxies have it. |
-| 2 | Forward Auth (external authentication) | Medium | Table-stakes | Sub-request to auth service (Authelia, Authentik, Keycloak) before proxying. Standard SSO/MFA mechanism. Traefik forwardAuth, Nginx auth_request. |
+| 1 | Forward Auth (external authentication) | Medium | Table-stakes | Sub-request to auth service (Authelia, Authentik, Keycloak) before proxying. Standard SSO/MFA mechanism. Traefik forwardAuth, Nginx auth_request. |
 | 3 | Custom Error Pages + Maintenance Mode | Low | Table-stakes | Change route `enabled: bool` to enum `active/maintenance/disabled`. Maintenance returns 503 with configurable HTML page. Custom error pages for 502/503/504/429. |
 
 ## Medium Priority

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,37 +1,28 @@
 # Technical Backlog
 
-Items identified during QA traceability audit (2026-04-01) and acceptance testing (2026-04-05/06).
-
 ## High Priority
 
-| Source | Description | References |
-|--------|-------------|------------|
-| ~~Security audit~~ | ~~**XFF Trust without validation**: resolved - trusted_proxies CIDR list added to global settings. XFF only trusted when direct client IP matches a configured proxy range. Empty = trust no XFF (secure default).~~ | ~~`proxy_wiring.rs`~~ |
+| # | Feature | Complexity | Type | Notes |
+|---|---------|-----------|------|-------|
+| 1 | Sticky Sessions (cookie-based) | Low | Table-stakes | Inject Set-Cookie with backend ID, lookup on next request. Essential for stateful apps (PHP sessions, e-commerce). All major proxies have it. |
+| 2 | Forward Auth (external authentication) | Medium | Table-stakes | Sub-request to auth service (Authelia, Authentik, Keycloak) before proxying. Standard SSO/MFA mechanism. Traefik forwardAuth, Nginx auth_request. |
+| 3 | Custom Error Pages + Maintenance Mode | Low | Table-stakes | Change route `enabled: bool` to enum `active/maintenance/disabled`. Maintenance returns 503 with configurable HTML page. Custom error pages for 502/503/504/429. |
 
 ## Medium Priority
 
-| Source | Description | References |
-|--------|-------------|------------|
-| *(empty - all medium items resolved)* | | |
+| # | Feature | Complexity | Type | Notes |
+|---|---------|-----------|------|-------|
+| 4 | Basic Auth per Route | Low | Table-stakes | HTTP Basic Auth on specific routes. Useful for staging, internal tools. |
+| 5 | Canary / Traffic Split | Medium | Differentiator | Route X% traffic to backend group A, Y% to group B. Zero-risk deployments. |
+| 6 | Header-Based Routing | Low-Medium | Differentiator | Route by HTTP headers (X-Version, X-Tenant). A/B testing, multi-tenant. |
+| 7 | Retry Policy (enriched) | Low-Medium | Table-stakes | Extend retry_attempts with retry_on (status codes), retry_methods, retry_backoff_ms. |
 
 ## Low Priority
 
-| Source | Description | References |
-|--------|-------------|------------|
-| *(empty - all low items resolved)* | | |
-
-## Resolved
-
-| Item | Resolution |
-|------|------------|
-| `#[allow(dead_code)]` on RouteEntry | Already removed by prior refactor |
-| `request_counts`/`waf_counts` DashMaps | Accepted: bounded by config (routes * status codes), low risk |
-| Rule 920100 unreachable | Fixed: added `content-length` and `transfer-encoding` to WAF header inspection list |
-| Mutex poisoning | Migrated to `parking_lot::Mutex/RwLock` across all crates |
-| WAF config propagation | Already functional via ConfigReload command channel |
-| WAF auto-ban per-worker | Fixed: global counter via supervisor + BanIp command broadcast |
-| WAF events in detection mode | Working via waf.sock forwarding + supervisor persistence |
-| Encryption key rotation | Implemented: `lorica rotate-key --new-key-file` CLI |
-| Export secret leak | Fixed: SMTP passwords and private keys redacted in exports |
-| Memory leak waf_violations | Fixed: entries removed on ban |
-| SQLite busy_timeout | Fixed: PRAGMA busy_timeout=5000 on access-log.db |
+| # | Feature | Complexity | Type | Notes |
+|---|---------|-----------|------|-------|
+| 8 | Structured JSON Logs (file/syslog) | Medium | Differentiator | Configurable log format, write to file/stdout/syslog. ELK/Loki/Datadog integration. |
+| 9 | Request Mirroring | Medium | Differentiator | Duplicate traffic to secondary backend (fire-and-forget). Shadow testing. |
+| 10 | mTLS Client Verification | Medium | Differentiator | Require client TLS certificate for specific routes. Zero-trust, B2B. |
+| 11 | Response Body Rewriting | Medium-High | Table-stakes | Replace strings in response body (Nginx sub_filter). URL rewriting for legacy apps. |
+| 12 | TCP/L4 Proxying | High | Differentiator | Stream proxy for databases, MQTT, SSH. SNI-based routing without TLS termination. |

--- a/lorica-api/Cargo.toml
+++ b/lorica-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-api"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -9,11 +9,11 @@ description = "REST API for Lorica reverse proxy management"
 
 [dependencies]
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-config = { version = "1.0.1", path = "../lorica-config" }
-lorica-dashboard = { version = "1.0.1", path = "../lorica-dashboard" }
+lorica-config = { version = "1.1.0", path = "../lorica-config" }
+lorica-dashboard = { version = "1.1.0", path = "../lorica-dashboard" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
-lorica-bench = { version = "1.0.1", path = "../lorica-bench" }
+lorica-bench = { version = "1.1.0", path = "../lorica-bench" }
 axum = { version = "0.7", features = ["multipart", "ws"] }
 futures-util = "0.3"
 tower = "0.4"

--- a/lorica-api/Cargo.toml
+++ b/lorica-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-api"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -9,11 +9,11 @@ description = "REST API for Lorica reverse proxy management"
 
 [dependencies]
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-config = { version = "1.0.0", path = "../lorica-config" }
-lorica-dashboard = { version = "1.0.0", path = "../lorica-dashboard" }
+lorica-config = { version = "1.0.1", path = "../lorica-config" }
+lorica-dashboard = { version = "1.0.1", path = "../lorica-dashboard" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
-lorica-bench = { version = "1.0.0", path = "../lorica-bench" }
+lorica-bench = { version = "1.0.1", path = "../lorica-bench" }
 axum = { version = "0.7", features = ["multipart", "ws"] }
 futures-util = "0.3"
 tower = "0.4"

--- a/lorica-api/openapi.yaml
+++ b/lorica-api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lorica API
   description: REST API for Lorica reverse proxy management
-  version: 1.0.1
+  version: 1.1.0
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/lorica-api/openapi.yaml
+++ b/lorica-api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lorica API
   description: REST API for Lorica reverse proxy management
-  version: 1.0.0
+  version: 1.0.1
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -221,6 +221,12 @@ paths:
                     type: string
                   description: CIDR ranges or IPs of trusted reverse proxies
                   example: ["192.168.0.0/16", "10.0.0.0/8"]
+                waf_whitelist_ips:
+                  type: array
+                  items:
+                    type: string
+                  description: IPs or CIDRs that bypass WAF, rate limiting, IP blocklist, and auto-ban
+                  example: ["203.0.113.50", "10.0.0.0/8"]
       responses:
         "200":
           description: Settings updated

--- a/lorica-api/src/log_store.rs
+++ b/lorica-api/src/log_store.rs
@@ -44,6 +44,7 @@ impl LogStore {
         let _ = conn.execute("ALTER TABLE access_logs ADD COLUMN is_xff INTEGER NOT NULL DEFAULT 0", []);
         let _ = conn.execute("ALTER TABLE access_logs ADD COLUMN xff_proxy_ip TEXT NOT NULL DEFAULT ''", []);
         let _ = conn.execute("ALTER TABLE access_logs ADD COLUMN source TEXT NOT NULL DEFAULT ''", []);
+        let _ = conn.execute("ALTER TABLE access_logs ADD COLUMN request_id TEXT NOT NULL DEFAULT ''", []);
 
         // Migrate: add columns to waf_events if missing
         let _ = conn.execute("ALTER TABLE waf_events ADD COLUMN client_ip TEXT NOT NULL DEFAULT ''", []);
@@ -95,8 +96,8 @@ impl LogStore {
     pub fn insert(&self, entry: &LogEntry) -> Result<(), String> {
         let conn = self.conn.lock();
         conn.execute(
-            "INSERT INTO access_logs (timestamp, method, path, host, status, latency_ms, backend, error, client_ip, is_xff, xff_proxy_ip, source)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            "INSERT INTO access_logs (timestamp, method, path, host, status, latency_ms, backend, error, client_ip, is_xff, xff_proxy_ip, source, request_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 entry.timestamp,
                 entry.method,
@@ -110,6 +111,7 @@ impl LogStore {
                 entry.is_xff as i64,
                 entry.xff_proxy_ip,
                 entry.source,
+                entry.request_id,
             ],
         )
         .map_err(|e| format!("failed to insert access log entry: {e}"))?;
@@ -184,7 +186,7 @@ impl LogStore {
             .map_err(|e| format!("failed to count access logs: {e}"))?;
 
         let query_sql = format!(
-            "SELECT id, timestamp, method, path, host, status, latency_ms, backend, error, client_ip, is_xff, xff_proxy_ip, source \
+            "SELECT id, timestamp, method, path, host, status, latency_ms, backend, error, client_ip, is_xff, xff_proxy_ip, source, request_id \
              FROM access_logs {where_clause} ORDER BY id DESC LIMIT ?",
         );
         let mut query_bind: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
@@ -214,6 +216,7 @@ impl LogStore {
                     is_xff: row.get::<_, i64>(10)? != 0,
                     xff_proxy_ip: row.get::<_, String>(11).unwrap_or_default(),
                     source: row.get::<_, String>(12).unwrap_or_default(),
+                    request_id: row.get::<_, String>(13).unwrap_or_default(),
                 })
             })
             .map_err(|e| format!("failed to query access logs: {e}"))?;
@@ -278,7 +281,7 @@ impl LogStore {
         };
 
         let query_sql = format!(
-            "SELECT id, timestamp, method, path, host, status, latency_ms, backend, error, client_ip, is_xff, xff_proxy_ip, source \
+            "SELECT id, timestamp, method, path, host, status, latency_ms, backend, error, client_ip, is_xff, xff_proxy_ip, source, request_id \
              FROM access_logs {where_clause} ORDER BY id ASC LIMIT ?",
         );
         bind_values.push(Box::new(max as i64));
@@ -304,6 +307,7 @@ impl LogStore {
                     is_xff: row.get::<_, i64>(10)? != 0,
                     xff_proxy_ip: row.get::<_, String>(11).unwrap_or_default(),
                     source: row.get::<_, String>(12).unwrap_or_default(),
+                    request_id: row.get::<_, String>(13).unwrap_or_default(),
                 })
             })
             .map_err(|e| format!("failed to query export logs: {e}"))?;

--- a/lorica-api/src/logs.rs
+++ b/lorica-api/src/logs.rs
@@ -621,6 +621,7 @@ mod tests {
             is_xff: false,
             xff_proxy_ip: String::new(),
             source: String::new(),
+            request_id: String::new(),
         })
         .await;
 

--- a/lorica-api/src/logs.rs
+++ b/lorica-api/src/logs.rs
@@ -34,6 +34,9 @@ pub struct LogEntry {
     /// Request source identifier (e.g., "loadtest" from X-Lorica-Source header).
     #[serde(default)]
     pub source: String,
+    /// Unique request ID for end-to-end tracing.
+    #[serde(default)]
+    pub request_id: String,
 }
 
 /// Thread-safe in-memory ring buffer for access logs with real-time broadcast.
@@ -390,7 +393,7 @@ pub async fn export_logs(
         ))
     } else {
         let mut csv = String::with_capacity(entries.len() * 120);
-        csv.push_str("timestamp,method,path,host,status,latency_ms,backend,client_ip,error\n");
+        csv.push_str("timestamp,method,path,host,status,latency_ms,backend,client_ip,error,request_id\n");
         for e in &entries {
             csv.push_str(&csv_escape(&e.timestamp));
             csv.push(',');
@@ -409,6 +412,8 @@ pub async fn export_logs(
             csv.push_str(&csv_escape(&e.client_ip));
             csv.push(',');
             csv.push_str(&csv_escape(e.error.as_deref().unwrap_or("")));
+            csv.push(',');
+            csv.push_str(&csv_escape(&e.request_id));
             csv.push('\n');
         }
         let filename = format!("lorica-logs-{today}.csv");
@@ -513,6 +518,7 @@ mod tests {
                 is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
             })
             .await;
         }
@@ -542,6 +548,7 @@ mod tests {
                 is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
             })
             .await;
         }

--- a/lorica-api/src/routes.rs
+++ b/lorica-api/src/routes.rs
@@ -97,6 +97,7 @@ pub struct RouteResponse {
     pub path_rules: Vec<PathRuleResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_status: Option<u16>,
+    pub sticky_session: bool,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -147,6 +148,7 @@ pub struct CreateRouteRequest {
     pub auto_ban_duration_s: Option<i32>,
     pub path_rules: Option<Vec<PathRuleRequest>>,
     pub return_status: Option<u16>,
+    pub sticky_session: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -196,6 +198,7 @@ pub struct UpdateRouteRequest {
     pub auto_ban_duration_s: Option<i32>,
     pub path_rules: Option<Vec<PathRuleRequest>>,
     pub return_status: Option<u16>,
+    pub sticky_session: Option<bool>,
 }
 
 fn route_to_response(
@@ -265,6 +268,7 @@ fn route_to_response(
             })
             .collect(),
         return_status: route.return_status,
+        sticky_session: route.sticky_session,
         created_at: route.created_at.to_rfc3339(),
         updated_at: route.updated_at.to_rfc3339(),
     }
@@ -390,6 +394,7 @@ pub async fn create_route(
         auto_ban_duration_s: body.auto_ban_duration_s.unwrap_or(3600),
         path_rules,
         return_status: body.return_status,
+        sticky_session: body.sticky_session.unwrap_or(false),
         created_at: now,
         updated_at: now,
     };
@@ -619,6 +624,9 @@ pub async fn update_route(
     }
     if let Some(return_status) = body.return_status {
         route.return_status = if return_status == 0 { None } else { Some(return_status) };
+    }
+    if let Some(sticky) = body.sticky_session {
+        route.sticky_session = sticky;
     }
     route.updated_at = Utc::now();
 

--- a/lorica-api/src/settings.rs
+++ b/lorica-api/src/settings.rs
@@ -34,6 +34,7 @@ pub struct UpdateSettingsRequest {
     pub sla_purge_schedule: Option<String>,
     pub custom_security_presets: Option<Vec<lorica_config::models::SecurityHeaderPreset>>,
     pub trusted_proxies: Option<Vec<String>>,
+    pub waf_whitelist_ips: Option<Vec<String>>,
 }
 
 /// PUT /api/v1/settings
@@ -162,6 +163,22 @@ pub async fn update_settings(
             }
         }
         settings.trusted_proxies = proxies.clone();
+    }
+    if let Some(ref ips) = body.waf_whitelist_ips {
+        for entry in ips {
+            let trimmed = entry.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if trimmed.parse::<std::net::IpAddr>().is_err()
+                && trimmed.parse::<ipnet::IpNet>().is_err()
+            {
+                return Err(ApiError::BadRequest(format!(
+                    "invalid WAF whitelist CIDR or IP: {trimmed}"
+                )));
+            }
+        }
+        settings.waf_whitelist_ips = ips.clone();
     }
 
     store.update_global_settings(&settings)?;

--- a/lorica-api/src/tests.rs
+++ b/lorica-api/src/tests.rs
@@ -962,6 +962,7 @@ async fn test_logs_endpoint_with_entries() {
                 is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
             })
             .await;
     }
@@ -1007,6 +1008,7 @@ async fn test_logs_endpoint_filtering() {
             is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
         })
         .await;
     state
@@ -1025,6 +1027,7 @@ async fn test_logs_endpoint_filtering() {
             is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
         })
         .await;
 
@@ -1084,6 +1087,7 @@ async fn test_clear_logs_endpoint() {
             is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
         })
         .await;
 
@@ -1139,6 +1143,7 @@ async fn test_logs_endpoint_status_range() {
                 is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
             })
             .await;
     }
@@ -1182,6 +1187,7 @@ async fn test_logs_endpoint_time_range() {
             is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
         })
         .await;
     state
@@ -1200,6 +1206,7 @@ async fn test_logs_endpoint_time_range() {
             is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
         })
         .await;
 
@@ -1244,6 +1251,7 @@ async fn test_logs_endpoint_limit_and_after_id() {
                 is_xff: false,
                 xff_proxy_ip: String::new(),
                 source: String::new(),
+                request_id: String::new(),
             })
             .await;
     }

--- a/lorica-bench/Cargo.toml
+++ b/lorica-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-bench"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -8,7 +8,7 @@ repository = "https://github.com/Rwx-G/Lorica"
 description = "SLA monitoring and load testing for Lorica reverse proxy"
 
 [dependencies]
-lorica-config = { version = "1.0.0", path = "../lorica-config" }
+lorica-config = { version = "1.0.1", path = "../lorica-config" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/lorica-bench/Cargo.toml
+++ b/lorica-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-bench"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -8,7 +8,7 @@ repository = "https://github.com/Rwx-G/Lorica"
 description = "SLA monitoring and load testing for Lorica reverse proxy"
 
 [dependencies]
-lorica-config = { version = "1.0.1", path = "../lorica-config" }
+lorica-config = { version = "1.1.0", path = "../lorica-config" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/lorica-bench/src/active_probes.rs
+++ b/lorica-bench/src/active_probes.rs
@@ -403,6 +403,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -494,6 +495,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/lorica-bench/src/passive_sla.rs
+++ b/lorica-bench/src/passive_sla.rs
@@ -302,11 +302,14 @@ impl SlaCollector {
             loop {
                 interval.tick().await;
 
-                // Flush buckets while holding the store lock, then release it
+                // Flush buckets while holding the store lock, then release it.
+                // Always check thresholds even if this process flushed nothing:
+                // in worker mode, workers flush SLA data to the DB and the
+                // supervisor must still check thresholds to dispatch alerts.
                 let (flushed, alerts) = {
                     let store_guard = store.lock().await;
                     let flushed = collector.flush(&store_guard);
-                    let alerts = if flushed > 0 {
+                    let alerts = if dispatcher.is_some() {
                         collector.check_thresholds(&store_guard)
                     } else {
                         Vec::new()

--- a/lorica-bench/src/passive_sla.rs
+++ b/lorica-bench/src/passive_sla.rs
@@ -588,6 +588,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -677,6 +678,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -781,6 +783,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -870,6 +873,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -942,6 +946,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/lorica-command/Cargo.toml
+++ b/lorica-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-command"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-command/Cargo.toml
+++ b/lorica-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-command"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/Cargo.toml
+++ b/lorica-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-config"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/Cargo.toml
+++ b/lorica-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-config"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/src/models.rs
+++ b/lorica-config/src/models.rs
@@ -620,6 +620,11 @@ pub struct GlobalSettings {
     /// Examples: `["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"]`.
     #[serde(default)]
     pub trusted_proxies: Vec<String>,
+    /// IP addresses or CIDR ranges that bypass WAF evaluation, rate limiting,
+    /// and auto-ban entirely. Use for admin/operator IPs to prevent self-blocking.
+    /// Examples: `["203.0.113.50", "10.0.0.0/8"]`.
+    #[serde(default)]
+    pub waf_whitelist_ips: Vec<String>,
 }
 
 fn default_security_headers() -> String {
@@ -733,6 +738,7 @@ impl Default for GlobalSettings {
             sla_purge_retention_days: default_sla_purge_retention_days(),
             sla_purge_schedule: default_sla_purge_schedule(),
             trusted_proxies: Vec::new(),
+            waf_whitelist_ips: Vec::new(),
         }
     }
 }

--- a/lorica-config/src/models.rs
+++ b/lorica-config/src/models.rs
@@ -416,6 +416,10 @@ pub struct Route {
     pub path_rules: Vec<PathRule>,
     #[serde(default)]
     pub return_status: Option<u16>,
+    /// Enable cookie-based sticky sessions (session affinity).
+    /// When enabled, a `LORICA_SRV` cookie is set with the backend ID.
+    #[serde(default)]
+    pub sticky_session: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -1329,6 +1333,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: now,
             updated_at: now,
         };

--- a/lorica-config/src/store.rs
+++ b/lorica-config/src/store.rs
@@ -348,15 +348,17 @@ impl ConfigStore {
                 "ALTER TABLE routes ADD COLUMN return_status INTEGER DEFAULT NULL",
                 [],
             );
-            let _ = self.conn.execute(
-                "ALTER TABLE routes ADD COLUMN sticky_session INTEGER NOT NULL DEFAULT 0",
-                [],
-            );
             self.conn.execute(
                 "INSERT OR IGNORE INTO schema_migrations (version) VALUES (?1)",
                 params![18],
             )?;
         }
+
+        // Unconditional column additions (idempotent, let _ = ignores "already exists")
+        let _ = self.conn.execute(
+            "ALTER TABLE routes ADD COLUMN sticky_session INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
 
         if current_version < 19 {
             tracing::info!("applying migration 017_acme_method");

--- a/lorica-config/src/store.rs
+++ b/lorica-config/src/store.rs
@@ -1512,6 +1512,14 @@ impl ConfigStore {
                             ))
                         })?;
                 }
+                "waf_whitelist_ips" => {
+                    settings.waf_whitelist_ips =
+                        serde_json::from_str(&value).map_err(|e| {
+                            ConfigError::Validation(format!(
+                                "invalid waf_whitelist_ips JSON: {e}"
+                            ))
+                        })?;
+                }
                 _ => {}
             }
         }
@@ -1591,6 +1599,14 @@ impl ConfigStore {
         self.conn.execute(
             "INSERT OR REPLACE INTO global_settings (key, value) VALUES ('trusted_proxies', ?1)",
             params![trusted_proxies_json],
+        )?;
+        let waf_whitelist_json =
+            serde_json::to_string(&settings.waf_whitelist_ips).map_err(|e| {
+                ConfigError::Validation(format!("failed to serialize waf_whitelist_ips: {e}"))
+            })?;
+        self.conn.execute(
+            "INSERT OR REPLACE INTO global_settings (key, value) VALUES ('waf_whitelist_ips', ?1)",
+            params![waf_whitelist_json],
         )?;
         Ok(())
     }

--- a/lorica-config/src/store.rs
+++ b/lorica-config/src/store.rs
@@ -348,6 +348,10 @@ impl ConfigStore {
                 "ALTER TABLE routes ADD COLUMN return_status INTEGER DEFAULT NULL",
                 [],
             );
+            let _ = self.conn.execute(
+                "ALTER TABLE routes ADD COLUMN sticky_session INTEGER NOT NULL DEFAULT 0",
+                [],
+            );
             self.conn.execute(
                 "INSERT OR IGNORE INTO schema_migrations (version) VALUES (?1)",
                 params![18],
@@ -504,12 +508,12 @@ impl ConfigStore {
              max_connections, slowloris_threshold_ms,
              auto_ban_threshold, auto_ban_duration_s,
              created_at, updated_at,
-             path_rules, return_status)
+             path_rules, return_status, sticky_session)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
                      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21,
                      ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32,
                      ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41, ?42, ?43, ?44, ?45,
-                     ?46, ?47)",
+                     ?46, ?47, ?48)",
             params![
                 route.id,
                 route.hostname,
@@ -558,6 +562,7 @@ impl ConfigStore {
                 route.updated_at.to_rfc3339(),
                 path_rules_json,
                 route.return_status.map(|v| v as i32),
+                route.sticky_session,
             ],
         )?;
         Ok(())
@@ -585,7 +590,7 @@ impl ConfigStore {
                  max_connections, slowloris_threshold_ms,
                  auto_ban_threshold, auto_ban_duration_s,
                  created_at, updated_at,
-                 path_rules, return_status
+                 path_rules, return_status, sticky_session
                  FROM routes WHERE id = ?1",
                 params![id],
                 |row| Ok(row_to_route(row)),
@@ -615,7 +620,7 @@ impl ConfigStore {
              max_connections, slowloris_threshold_ms,
              auto_ban_threshold, auto_ban_duration_s,
              created_at, updated_at,
-             path_rules, return_status
+             path_rules, return_status, sticky_session
              FROM routes ORDER BY hostname, path_prefix",
         )?;
         let rows = stmt.query_map([], |row| Ok(row_to_route(row)))?;
@@ -671,7 +676,7 @@ impl ConfigStore {
              max_connections=?40, slowloris_threshold_ms=?41,
              auto_ban_threshold=?42, auto_ban_duration_s=?43,
              updated_at=?44,
-             path_rules=?45, return_status=?46 WHERE id=?1",
+             path_rules=?45, return_status=?46, sticky_session=?47 WHERE id=?1",
             params![
                 route.id,
                 route.hostname,
@@ -719,6 +724,7 @@ impl ConfigStore {
                 route.updated_at.to_rfc3339(),
                 path_rules_json,
                 route.return_status.map(|v| v as i32),
+                route.sticky_session,
             ],
         )?;
         if changed == 0 {
@@ -2732,6 +2738,7 @@ fn row_to_route(row: &rusqlite::Row<'_>) -> Result<Route> {
         auto_ban_duration_s: row.get(42)?,
         path_rules,
         return_status,
+        sticky_session: row.get::<_, bool>(47).unwrap_or(false),
         created_at: parse_datetime(&row.get::<_, String>(43)?)?,
         updated_at: parse_datetime(&row.get::<_, String>(44)?)?,
     })

--- a/lorica-config/src/tests.rs
+++ b/lorica-config/src/tests.rs
@@ -57,6 +57,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: now,
             updated_at: now,
         }
@@ -1503,5 +1504,34 @@ cert_critical_days = 3
 
         let count = store.rotate_encryption_key(&key2).unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_sticky_session_persistence() {
+        let store = ConfigStore::open_in_memory().unwrap();
+        let mut route = make_route();
+        route.sticky_session = true;
+        store.create_route(&route).unwrap();
+
+        let loaded = store.get_route(&route.id).unwrap().unwrap();
+        assert!(loaded.sticky_session, "sticky_session should persist as true");
+
+        // Toggle off
+        let mut updated = loaded;
+        updated.sticky_session = false;
+        store.update_route(&updated).unwrap();
+
+        let reloaded = store.get_route(&route.id).unwrap().unwrap();
+        assert!(!reloaded.sticky_session, "sticky_session should persist as false");
+    }
+
+    #[test]
+    fn test_sticky_session_default_false() {
+        let store = ConfigStore::open_in_memory().unwrap();
+        let route = make_route();
+        store.create_route(&route).unwrap();
+
+        let loaded = store.get_route(&route.id).unwrap().unwrap();
+        assert!(!loaded.sticky_session, "sticky_session should default to false");
     }
 }

--- a/lorica-dashboard/Cargo.toml
+++ b/lorica-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-dashboard"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/Cargo.toml
+++ b/lorica-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-dashboard"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/frontend/package.json
+++ b/lorica-dashboard/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/lorica-dashboard/frontend/package.json
+++ b/lorica-dashboard/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/lorica-dashboard/frontend/src/components/route-tabs/GeneralTab.svelte
+++ b/lorica-dashboard/frontend/src/components/route-tabs/GeneralTab.svelte
@@ -196,6 +196,14 @@
     </label>
     {#if isImported('compression_enabled')}<span class="imported-badge">imported</span>{/if}
   </div>
+
+  <div class="form-group" class:modified={isModified('sticky_session')}>
+    <label class="checkbox-item">
+      <input type="checkbox" bind:checked={form.sticky_session} />
+      <span>Sticky sessions</span>
+    </label>
+    <span class="hint">Routes returning clients to the same backend via a cookie (LORICA_SRV). Useful for stateful applications.</span>
+  </div>
 </div>
 
 <style>

--- a/lorica-dashboard/frontend/src/lib/api.ts
+++ b/lorica-dashboard/frontend/src/lib/api.ts
@@ -148,6 +148,7 @@ export interface RouteResponse {
   auto_ban_duration_s: number;
   path_rules: PathRuleResponse[];
   return_status: number | null;
+  sticky_session: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -197,6 +198,7 @@ export interface CreateRouteRequest {
   auto_ban_duration_s?: number;
   path_rules?: PathRuleRequest[];
   return_status?: number;
+  sticky_session?: boolean;
 }
 
 export interface UpdateRouteRequest {
@@ -245,6 +247,7 @@ export interface UpdateRouteRequest {
   auto_ban_duration_s?: number;
   path_rules?: PathRuleRequest[];
   return_status?: number;
+  sticky_session?: boolean;
 }
 
 export interface BackendResponse {

--- a/lorica-dashboard/frontend/src/lib/api.ts
+++ b/lorica-dashboard/frontend/src/lib/api.ts
@@ -321,6 +321,7 @@ export interface LogEntry {
   is_xff: boolean;
   xff_proxy_ip: string;
   source: string;
+  request_id: string;
 }
 
 export interface LogsResponse {

--- a/lorica-dashboard/frontend/src/lib/route-form.ts
+++ b/lorica-dashboard/frontend/src/lib/route-form.ts
@@ -60,6 +60,7 @@ export interface RouteFormState {
   auto_ban_duration_s: number;
   path_rules: PathRuleFormState[];
   return_status: string;
+  sticky_session: boolean;
 }
 
 export const ROUTE_DEFAULTS: RouteFormState = {
@@ -108,6 +109,7 @@ export const ROUTE_DEFAULTS: RouteFormState = {
   auto_ban_duration_s: 3600,
   path_rules: [],
   return_status: '',
+  sticky_session: false,
 };
 
 // Tab field mappings for dot indicators
@@ -115,7 +117,7 @@ export const TAB_FIELDS: Record<string, (keyof RouteFormState)[]> = {
   general: [
     'hostname', 'path_prefix', 'force_https', 'redirect_hostname', 'redirect_to',
     'hostname_aliases', 'websocket_enabled', 'access_log_enabled',
-    'compression_enabled', 'waf_enabled', 'return_status',
+    'compression_enabled', 'waf_enabled', 'return_status', 'sticky_session',
   ],
   timeouts: [
     'connect_timeout_s', 'read_timeout_s', 'send_timeout_s',
@@ -226,6 +228,7 @@ export function routeToFormState(route: RouteResponse): RouteFormState {
       return_status: r.return_status != null ? String(r.return_status) : '',
     })),
     return_status: route.return_status != null ? String(route.return_status) : '',
+    sticky_session: route.sticky_session ?? false,
   };
 }
 
@@ -290,6 +293,7 @@ function buildAdvancedFields(form: RouteFormState, isUpdate = false) {
     auto_ban_duration_s: form.auto_ban_duration_s,
     path_rules: pathRuleFormToRequest(form.path_rules) ?? (isUpdate ? [] : undefined),
     return_status: form.return_status ? Number(form.return_status) : empty(0),
+    sticky_session: form.sticky_session,
   };
 }
 

--- a/lorica-dashboard/frontend/src/routes/Logs.svelte
+++ b/lorica-dashboard/frontend/src/routes/Logs.svelte
@@ -15,7 +15,8 @@
   let filterClientIp = $state('');
   let filterStatusCategory = $state('');
   let filterTimeRange = $state('');
-  let autoRefresh = $state(true);
+  let filterLimit = $state(500);
+  let autoRefresh = $state(localStorage.getItem('lorica-logs-autorefresh') !== 'false');
 
   // Export controls
   let showExport = $state(false);
@@ -101,7 +102,7 @@
   }
 
   async function loadLogs() {
-    const params: LogsQuery = { limit: 500 };
+    const params: LogsQuery = { limit: filterLimit };
     if (searchText.trim()) params.search = searchText.trim();
     if (filterRoute.trim()) params.route = filterRoute.trim();
     if (filterClientIp.trim()) params.client_ip = filterClientIp.trim();
@@ -174,8 +175,8 @@
   }
 
   onMount(() => {
-    loadLogs();          // Initial load via REST
-    connectWebSocket();  // Then switch to real-time WS
+    loadLogs();
+    if (autoRefresh) connectWebSocket();
   });
 
   onDestroy(() => {
@@ -183,11 +184,14 @@
     disconnectWebSocket();
   });
 
-  // Restart auto-refresh when toggle changes
+  // React to auto-refresh toggle: connect/disconnect WS + polling
   $effect(() => {
+    localStorage.setItem('lorica-logs-autorefresh', String(autoRefresh));
     if (autoRefresh) {
+      connectWebSocket();
       startAutoRefresh();
     } else {
+      disconnectWebSocket();
       stopAutoRefresh();
     }
   });
@@ -283,7 +287,14 @@
         <option value={tr.value}>{tr.label}</option>
       {/each}
     </select>
-    <span class="entry-count">{total} entries</span>
+    <select class="filter-select" bind:value={filterLimit} onchange={loadLogs}>
+      <option value={100}>100</option>
+      <option value={500}>500</option>
+      <option value={1000}>1 000</option>
+      <option value={5000}>5 000</option>
+      <option value={10000}>10 000</option>
+    </select>
+    <span class="entry-count">{entries.length === total ? `${total} entries` : `${entries.length} of ${total} entries`}</span>
   </div>
 
   {#if error}

--- a/lorica-dashboard/frontend/src/routes/Logs.svelte
+++ b/lorica-dashboard/frontend/src/routes/Logs.svelte
@@ -60,8 +60,8 @@
         const entry: LogEntry = JSON.parse(event.data);
         // Apply client-side filters before adding
         if (matchesFilters(entry)) {
-          entries = [...entries.slice(-499), entry];
-          total = entries.length;
+          entries = [...entries.slice(-(filterLimit - 1)), entry];
+          total += 1;
         }
       } catch { /* ignore malformed messages */ }
     };

--- a/lorica-dashboard/frontend/src/routes/Security.svelte
+++ b/lorica-dashboard/frontend/src/routes/Security.svelte
@@ -221,7 +221,13 @@
       xss: 'XSS',
       path_traversal: 'Path Traversal',
       command_injection: 'Cmd Injection',
-      protocol_violation: 'Protocol',
+      protocol_violation: 'Protocol Violation',
+      SSRF: 'SSRF',
+      log_injection: 'Log4Shell/JNDI',
+      XXE: 'XXE',
+      ip_blocklist: 'IP Blocklist',
+      SSTI: 'SSTI',
+      prototype_pollution: 'Prototype Pollution',
     };
     return labels[cat] ?? cat;
   }
@@ -306,6 +312,12 @@
         <option value="path_traversal">Path Traversal</option>
         <option value="command_injection">Command Injection</option>
         <option value="protocol_violation">Protocol Violation</option>
+        <option value="SSRF">SSRF</option>
+        <option value="log_injection">Log4Shell/JNDI</option>
+        <option value="XXE">XXE</option>
+        <option value="ip_blocklist">IP Blocklist</option>
+        <option value="SSTI">SSTI</option>
+        <option value="prototype_pollution">Prototype Pollution</option>
       </select>
     </div>
 

--- a/lorica-dashboard/frontend/src/routes/Settings.svelte
+++ b/lorica-dashboard/frontend/src/routes/Settings.svelte
@@ -16,7 +16,7 @@
 
   // Global settings
   let settings: GlobalSettingsResponse | null = $state(null);
-  let settingsForm = $state({ management_port: 9443, log_level: 'info', default_health_check_interval_s: 10, cert_warning_days: 30, cert_critical_days: 7, max_global_connections: 0, flood_threshold_rps: 0, waf_ban_threshold: 5, waf_ban_duration_s: 3600, access_log_retention: 100000, sla_purge_enabled: false, sla_purge_retention_days: 90, sla_purge_schedule: 'first_of_month', trusted_proxies: '' });
+  let settingsForm = $state({ management_port: 9443, log_level: 'info', default_health_check_interval_s: 10, cert_warning_days: 30, cert_critical_days: 7, max_global_connections: 0, flood_threshold_rps: 0, waf_ban_threshold: 5, waf_ban_duration_s: 3600, access_log_retention: 100000, sla_purge_enabled: false, sla_purge_retention_days: 90, sla_purge_schedule: 'first_of_month', trusted_proxies: '', waf_whitelist_ips: '' });
   let settingsSaving = $state(false);
   let settingsMsg = $state('');
   let settingsError = $state('');
@@ -138,7 +138,7 @@
       error = settingsRes.error.message;
     } else if (settingsRes.data) {
       settings = settingsRes.data;
-      settingsForm = { ...settingsRes.data, trusted_proxies: (settingsRes.data.trusted_proxies ?? []).join('\n') };
+      settingsForm = { ...settingsRes.data, trusted_proxies: (settingsRes.data.trusted_proxies ?? []).join('\n'), waf_whitelist_ips: (settingsRes.data.waf_whitelist_ips ?? []).join('\n') };
       customPresets = settingsRes.data.custom_security_presets ?? [];
     }
     if (notifRes.data) {
@@ -184,10 +184,14 @@
     settingsSaving = true;
     settingsMsg = '';
     settingsError = '';
-    // Convert trusted_proxies textarea (newline-separated) to string array
+    // Convert textarea fields (newline-separated) to string arrays
     const payload = {
       ...settingsForm,
       trusted_proxies: settingsForm.trusted_proxies
+        .split('\n')
+        .map((s: string) => s.trim())
+        .filter((s: string) => s.length > 0),
+      waf_whitelist_ips: settingsForm.waf_whitelist_ips
         .split('\n')
         .map((s: string) => s.trim())
         .filter((s: string) => s.length > 0),
@@ -197,7 +201,7 @@
       settingsError = res.error.message;
     } else if (res.data) {
       settings = res.data;
-      settingsForm = { ...res.data, trusted_proxies: (res.data.trusted_proxies ?? []).join('\n') };
+      settingsForm = { ...res.data, trusted_proxies: (res.data.trusted_proxies ?? []).join('\n'), waf_whitelist_ips: (res.data.waf_whitelist_ips ?? []).join('\n') };
       settingsMsg = 'Settings saved.';
       setTimeout(() => settingsMsg = '', 3000);
     }
@@ -467,6 +471,11 @@
           <label for="trusted-proxies">Trusted Proxies (CIDR)</label>
           <textarea id="trusted-proxies" rows="4" bind:value={settingsForm.trusted_proxies} placeholder="192.168.0.0/16&#10;10.0.0.0/8&#10;172.16.0.0/12"></textarea>
           <span class="hint">One CIDR range or IP per line. X-Forwarded-For is only trusted from these addresses. Empty = trust no XFF (direct client IP always used).</span>
+        </div>
+        <div class="settings-form-row">
+          <label for="waf-whitelist">WAF Whitelist IPs</label>
+          <textarea id="waf-whitelist" rows="3" bind:value={settingsForm.waf_whitelist_ips} placeholder="203.0.113.50&#10;10.0.0.0/8"></textarea>
+          <span class="hint">One IP or CIDR per line. These IPs bypass WAF, rate limiting, IP blocklist, and auto-ban entirely. Use for admin/operator IPs.</span>
         </div>
         <div class="settings-form-row">
           <label for="s-log-retention">Access Log Retention (entries)</label>

--- a/lorica-dashboard/frontend/src/routes/Sla.svelte
+++ b/lorica-dashboard/frontend/src/routes/Sla.svelte
@@ -279,9 +279,9 @@
                   </tr>
                 </thead>
                 <tbody>
-                  {#each buckets.slice(-30) as b}
+                  {#each [...buckets].reverse().slice(0, 30) as b}
                     <tr>
-                      <td class="mono">{new Date(b.bucket_start).toLocaleTimeString()}</td>
+                      <td class="mono">{new Date(b.bucket_start).toLocaleString([], { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' })}</td>
                       <td>{b.request_count}</td>
                       <td style="color: var(--color-green)">{b.success_count}</td>
                       <td style="color: {b.error_count > 0 ? 'var(--color-red)' : 'var(--color-text-muted)'}">{b.error_count}</td>

--- a/lorica-waf/src/engine.rs
+++ b/lorica-waf/src/engine.rs
@@ -420,10 +420,16 @@ impl WafEngine {
     }
 
     /// Scan a single field against all enabled rules.
+    /// When `field` is "body", rules that don't apply to body content
+    /// (e.g. path traversal, protocol violations) are skipped.
     fn scan_field(&self, field: &str, value: &str, timestamp: &str, events: &mut Vec<WafEvent>) {
+        let is_body = field == "body";
         let disabled = self.disabled_rules.read();
         for rule in self.ruleset.rules() {
             if disabled.contains(&rule.id) {
+                continue;
+            }
+            if is_body && !rule.applies_to_body() {
                 continue;
             }
             if rule.pattern.is_match(value) {
@@ -1036,6 +1042,25 @@ mod tests {
         let body = b"username=admin&password=securePassword123";
         let verdict = e.evaluate_body(WafMode::Blocking, body, "example.com", "10.0.0.1");
         assert_eq!(verdict, WafVerdict::Pass);
+    }
+
+    #[test]
+    fn test_body_path_traversal_not_scanned() {
+        // Path traversal patterns in body content (e.g. CMS articles) should
+        // NOT trigger WAF rules - these rules only apply to path/query/headers.
+        let e = engine();
+        let body = br#"{"content": "Navigate to ..\ or ../ to go back"}"#;
+        let verdict = e.evaluate_body(WafMode::Blocking, body, "example.com", "10.0.0.1");
+        assert_eq!(verdict, WafVerdict::Pass);
+    }
+
+    #[test]
+    fn test_body_sqli_still_caught() {
+        // SQLi in body should still be caught (applies_to_body = true)
+        let e = engine();
+        let body = b"search=1 UNION SELECT * FROM users";
+        let verdict = e.evaluate_body(WafMode::Blocking, body, "example.com", "10.0.0.1");
+        assert!(matches!(verdict, WafVerdict::Blocked(_)));
     }
 
     #[test]

--- a/lorica-waf/src/rules.rs
+++ b/lorica-waf/src/rules.rs
@@ -435,6 +435,123 @@ impl RuleSet {
                 ).unwrap(),
                 severity: 4,
             },
+            // --- SQL Injection: auth bypass & evasion ---
+            WafRule {
+                id: 942170,
+                description: "SQL injection via authentication bypass",
+                category: RuleCategory::SqlInjection,
+                pattern: Regex::new(
+                    r"(?i)('|%27)\s*(or|and)\s*('|%27|\d+\s*=\s*\d+|true|1\s*--|'\s*=\s*')",
+                ).unwrap(),
+                severity: 5,
+            },
+            WafRule {
+                id: 942180,
+                description: "SQL injection via information schema reconnaissance",
+                category: RuleCategory::SqlInjection,
+                pattern: Regex::new(
+                    r"(?i)\b(information_schema|sys\.(tables|columns|objects)|pg_catalog|pg_tables|sqlite_master|mysql\.user)\b",
+                ).unwrap(),
+                severity: 4,
+            },
+            WafRule {
+                id: 942190,
+                description: "SQL injection via CHAR/CONCAT/HEX encoding evasion",
+                category: RuleCategory::SqlInjection,
+                pattern: Regex::new(
+                    r"(?i)\b(char|chr|concat|concat_ws|hex|unhex|conv)\s*\(\s*\d+",
+                ).unwrap(),
+                severity: 4,
+            },
+            // --- NoSQL Injection ---
+            WafRule {
+                id: 942200,
+                description: "NoSQL injection via MongoDB operators",
+                category: RuleCategory::SqlInjection,
+                pattern: Regex::new(
+                    r#"(?i)(\$(?:ne|eq|gt|lt|gte|lte|in|nin|regex|exists|where|or|and|not|nor)\b|\{\s*["\']?\$(?:gt|ne|regex|where))"#,
+                ).unwrap(),
+                severity: 5,
+            },
+            // --- Additional XSS ---
+            WafRule {
+                id: 941160,
+                description: "XSS via JavaScript eval/constructor execution",
+                category: RuleCategory::Xss,
+                pattern: Regex::new(
+                    r"(?i)\b(eval|settimeout|setinterval|function|constructor)\s*\(",
+                ).unwrap(),
+                severity: 5,
+            },
+            WafRule {
+                id: 941170,
+                description: "XSS via base64 obfuscated payload",
+                category: RuleCategory::Xss,
+                pattern: Regex::new(
+                    r"(?i)(atob|btoa)\s*\(|data\s*:\s*[^;]*;base64\s*,",
+                ).unwrap(),
+                severity: 4,
+            },
+            // --- Backup/sensitive file access ---
+            WafRule {
+                id: 930130,
+                description: "Backup or sensitive file access",
+                category: RuleCategory::PathTraversal,
+                pattern: Regex::new(
+                    r"(?i)\.(bak|backup|old|orig|save|swp|swo|tmp|temp|dist|copy|sql|tar\.gz|zip|rar|7z|log|conf|cfg|ini)\s*$",
+                ).unwrap(),
+                severity: 5,
+            },
+            // --- Windows command injection ---
+            WafRule {
+                id: 932130,
+                description: "Command injection via PowerShell/Windows binaries",
+                category: RuleCategory::CommandInjection,
+                pattern: Regex::new(
+                    r"(?i)\b(powershell|cmd\.exe|certutil|bitsadmin|mshta|wscript|cscript|regsvr32|rundll32)\b",
+                ).unwrap(),
+                severity: 5,
+            },
+            // --- HTTP request smuggling ---
+            WafRule {
+                id: 920140,
+                description: "HTTP request smuggling via Transfer-Encoding manipulation",
+                category: RuleCategory::ProtocolViolation,
+                pattern: Regex::new(
+                    r"(?i)(transfer-encoding\s*:.*chunked.*chunked|transfer-encoding\s*:.*,|content-length.*transfer-encoding|transfer-encoding.*content-length)",
+                ).unwrap(),
+                severity: 5,
+            },
+            // --- Scanner/bot detection ---
+            WafRule {
+                id: 913100,
+                description: "Automated scanner/attack tool detected",
+                category: RuleCategory::ProtocolViolation,
+                pattern: Regex::new(
+                    r"(?i)(nikto|sqlmap|nmap|masscan|dirbuster|gobuster|feroxbuster|nuclei|wpscan|acunetix|nessus|burpsuite|zgrab|httpx|subfinder)",
+                ).unwrap(),
+                severity: 3,
+            },
+            // --- Deserialization attacks ---
+            WafRule {
+                id: 944130,
+                description: "PHP/Java deserialization attack",
+                category: RuleCategory::LogInjection,
+                pattern: Regex::new(
+                    r#"(?i)(O:\d+:"[^"]+"|rO0ABX|aced0005|java\.lang\.(ProcessBuilder|Runtime)|php://input|php://filter)"#,
+                ).unwrap(),
+                severity: 5,
+            },
+            // --- HTTP method abuse ---
+            WafRule {
+                id: 920150,
+                description: "Dangerous HTTP method (TRACE/DEBUG/WebDAV)",
+                category: RuleCategory::ProtocolViolation,
+                pattern: Regex::new(
+                    r"(?i)^(TRACE|TRACK|CONNECT|DEBUG|PROPFIND|PROPPATCH|MKCOL|COPY|MOVE|LOCK|UNLOCK)\s",
+                ).unwrap(),
+                severity: 3,
+            },
         ];
 
         Self { rules }
@@ -748,5 +865,118 @@ mod tests {
         assert_eq!(RuleCategory::SSRF.as_str(), "SSRF");
         assert_eq!(RuleCategory::LogInjection.as_str(), "log_injection");
         assert_eq!(RuleCategory::XXE.as_str(), "XXE");
+    }
+
+    // --- New rules (v1.0.1) ---
+
+    #[test]
+    fn test_sqli_auth_bypass() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 942170).unwrap();
+        assert!(rule.pattern.is_match("' OR '1'='1"));
+        assert!(rule.pattern.is_match("' or true--"));
+        assert!(rule.pattern.is_match("%27 OR 1=1"));
+        assert!(!rule.pattern.is_match("username=admin"));
+    }
+
+    #[test]
+    fn test_sqli_info_schema() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 942180).unwrap();
+        assert!(rule.pattern.is_match("SELECT * FROM information_schema.tables"));
+        assert!(rule.pattern.is_match("sqlite_master"));
+        assert!(rule.pattern.is_match("pg_catalog"));
+        assert!(!rule.pattern.is_match("SELECT name FROM users"));
+    }
+
+    #[test]
+    fn test_sqli_encoding_evasion() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 942190).unwrap();
+        assert!(rule.pattern.is_match("CHAR(0x61,0x64)"));
+        assert!(rule.pattern.is_match("concat(0x7e,version())"));
+        assert!(!rule.pattern.is_match("character set utf8"));
+    }
+
+    #[test]
+    fn test_nosql_injection() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 942200).unwrap();
+        assert!(rule.pattern.is_match(r#"{"$gt":""}"#));
+        assert!(rule.pattern.is_match("$where"));
+        assert!(rule.pattern.is_match("$ne"));
+        assert!(!rule.pattern.is_match("total: $100"));
+    }
+
+    #[test]
+    fn test_xss_eval() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 941160).unwrap();
+        assert!(rule.pattern.is_match("eval('alert(1)')"));
+        assert!(rule.pattern.is_match("setTimeout(payload)"));
+        assert!(rule.pattern.is_match("constructor('return this')"));
+        assert!(!rule.pattern.is_match("evaluate the results"));
+    }
+
+    #[test]
+    fn test_xss_base64() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 941170).unwrap();
+        assert!(rule.pattern.is_match("atob('YWxlcnQ=')"));
+        assert!(rule.pattern.is_match("data:text/html;base64,PHNjcmlwdD4="));
+        assert!(!rule.pattern.is_match("database connection"));
+    }
+
+    #[test]
+    fn test_backup_file_access() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 930130).unwrap();
+        assert!(rule.pattern.is_match("/config.bak"));
+        assert!(rule.pattern.is_match("/dump.sql"));
+        assert!(rule.pattern.is_match("/site.tar.gz"));
+        assert!(!rule.pattern.is_match("/style.css"));
+    }
+
+    #[test]
+    fn test_powershell_injection() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 932130).unwrap();
+        assert!(rule.pattern.is_match("powershell -enc"));
+        assert!(rule.pattern.is_match("certutil -urlcache"));
+        assert!(!rule.pattern.is_match("power supply"));
+    }
+
+    #[test]
+    fn test_request_smuggling() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 920140).unwrap();
+        assert!(rule.pattern.is_match("transfer-encoding: chunked chunked"));
+        assert!(rule.pattern.is_match("transfer-encoding: chunked, identity"));
+    }
+
+    #[test]
+    fn test_scanner_detection() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 913100).unwrap();
+        assert!(rule.pattern.is_match("sqlmap/1.0"));
+        assert!(rule.pattern.is_match("Nikto/2.1.6"));
+        assert!(rule.pattern.is_match("nuclei"));
+        assert!(!rule.pattern.is_match("Mozilla/5.0"));
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let rs = RuleSet::default_crs();
+        let rule = rs.rules().iter().find(|r| r.id == 944130).unwrap();
+        assert!(rule.pattern.is_match(r#"O:4:"User":1:{}"#));
+        assert!(rule.pattern.is_match("rO0ABX"));
+        assert!(rule.pattern.is_match("php://filter/convert.base64-encode"));
+        assert!(!rule.pattern.is_match("photos of cats"));
+    }
+
+    #[test]
+    fn test_rule_count() {
+        let rs = RuleSet::default_crs();
+        assert_eq!(rs.len(), 49);
     }
 }

--- a/lorica-waf/src/rules.rs
+++ b/lorica-waf/src/rules.rs
@@ -84,6 +84,19 @@ pub struct WafRule {
     pub severity: u8,
 }
 
+impl WafRule {
+    /// Whether this rule should be evaluated during body scanning.
+    /// Path-specific rules (path traversal, sensitive file access, protocol
+    /// violations) are skipped for body content to avoid false positives
+    /// on CMS articles, JSON payloads, and form submissions.
+    pub fn applies_to_body(&self) -> bool {
+        !matches!(
+            self.category,
+            RuleCategory::PathTraversal | RuleCategory::ProtocolViolation
+        )
+    }
+}
+
 impl std::fmt::Debug for WafRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WafRule")

--- a/lorica-worker/Cargo.toml
+++ b/lorica-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-worker"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-worker/Cargo.toml
+++ b/lorica-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-worker"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica/Cargo.toml
+++ b/lorica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -29,21 +29,21 @@ lorica-http = { version = "0.1.0", path = "../lorica-http" }
 lorica-timeout = { version = "0.1.0", path = "../lorica-timeout" }
 lorica-lb = { version = "0.1.0", path = "../lorica-lb", optional = true, default-features = false }
 lorica-proxy = { version = "0.1.0", path = "../lorica-proxy", optional = true, default-features = false }
-lorica-config = { version = "1.0.0", path = "../lorica-config" }
-lorica-api = { version = "1.0.0", path = "../lorica-api" }
+lorica-config = { version = "1.0.1", path = "../lorica-config" }
+lorica-api = { version = "1.0.1", path = "../lorica-api" }
 lorica-error = { version = "0.1.0", path = "../lorica-error" }
 lorica-tls = { version = "0.1.0", path = "../lorica-tls" }
-lorica-worker = { version = "1.0.0", path = "../lorica-worker" }
-lorica-command = { version = "1.0.0", path = "../lorica-command" }
+lorica-worker = { version = "1.0.1", path = "../lorica-worker" }
+lorica-command = { version = "1.0.1", path = "../lorica-command" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 lorica-limits = { version = "0.1.0", path = "../lorica-limits" }
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
 once_cell = { workspace = true }
-lorica-bench = { version = "1.0.0", path = "../lorica-bench" }
+lorica-bench = { version = "1.0.1", path = "../lorica-bench" }
 regex = "1"
 bytes = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "cookies", "json"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 futures-util = "0.3"
 arc-swap = "1"

--- a/lorica/Cargo.toml
+++ b/lorica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -29,18 +29,18 @@ lorica-http = { version = "0.1.0", path = "../lorica-http" }
 lorica-timeout = { version = "0.1.0", path = "../lorica-timeout" }
 lorica-lb = { version = "0.1.0", path = "../lorica-lb", optional = true, default-features = false }
 lorica-proxy = { version = "0.1.0", path = "../lorica-proxy", optional = true, default-features = false }
-lorica-config = { version = "1.0.1", path = "../lorica-config" }
-lorica-api = { version = "1.0.1", path = "../lorica-api" }
+lorica-config = { version = "1.1.0", path = "../lorica-config" }
+lorica-api = { version = "1.1.0", path = "../lorica-api" }
 lorica-error = { version = "0.1.0", path = "../lorica-error" }
 lorica-tls = { version = "0.1.0", path = "../lorica-tls" }
-lorica-worker = { version = "1.0.1", path = "../lorica-worker" }
-lorica-command = { version = "1.0.1", path = "../lorica-command" }
+lorica-worker = { version = "1.1.0", path = "../lorica-worker" }
+lorica-command = { version = "1.1.0", path = "../lorica-command" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 lorica-limits = { version = "0.1.0", path = "../lorica-limits" }
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
 once_cell = { workspace = true }
-lorica-bench = { version = "1.0.1", path = "../lorica-bench" }
+lorica-bench = { version = "1.1.0", path = "../lorica-bench" }
 regex = "1"
 bytes = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "cookies", "json"] }

--- a/lorica/src/main.rs
+++ b/lorica/src/main.rs
@@ -114,6 +114,19 @@ enum Commands {
         #[arg(long)]
         new_key_file: String,
     },
+    /// Remove an IP from the auto-ban list
+    Unban {
+        /// IP address to unban
+        ip: String,
+
+        /// Admin username
+        #[arg(long, default_value = "admin")]
+        user: String,
+
+        /// Admin password
+        #[arg(long)]
+        password: String,
+    },
 }
 
 fn init_logging(log_level: &str) {
@@ -197,6 +210,53 @@ fn main() {
             );
             println!("  mv {} {}.backup", key_path.display(), key_path.display());
             println!("  mv {} {}", new_key_path.display(), key_path.display());
+        }
+        Some(Commands::Unban { ip, user, password }) => {
+            let port = cli.management_port;
+            let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+            rt.block_on(async {
+                let client = reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .cookie_store(true)
+                    .build()
+                    .expect("HTTP client");
+
+                // Login
+                let login_url = format!("https://127.0.0.1:{port}/api/v1/auth/login");
+                let login_res = client
+                    .post(&login_url)
+                    .json(&serde_json::json!({ "username": user, "password": password }))
+                    .send()
+                    .await;
+                match login_res {
+                    Ok(r) if r.status().is_success() => {}
+                    Ok(r) => {
+                        eprintln!("Login failed ({}). Check credentials.", r.status());
+                        std::process::exit(1);
+                    }
+                    Err(e) => {
+                        eprintln!("Cannot connect to management API on port {port}: {e}");
+                        std::process::exit(1);
+                    }
+                }
+
+                // Unban
+                let unban_url = format!("https://127.0.0.1:{port}/api/v1/bans/{ip}");
+                match client.delete(&unban_url).send().await {
+                    Ok(r) if r.status().is_success() => {
+                        println!("IP {ip} unbanned successfully.");
+                    }
+                    Ok(r) => {
+                        let body = r.text().await.unwrap_or_default();
+                        eprintln!("Unban failed: {body}");
+                        std::process::exit(1);
+                    }
+                    Err(e) => {
+                        eprintln!("Unban request failed: {e}");
+                        std::process::exit(1);
+                    }
+                }
+            });
         }
         None => {
             init_logging(&cli.log_level);

--- a/lorica/src/main.rs
+++ b/lorica/src/main.rs
@@ -1812,7 +1812,7 @@ fn run_single_process(cli: Cli) {
         let proxy_ban_list = Arc::clone(&lorica_proxy.ban_list);
         let proxy_ewma_scores = lorica_proxy.ewma_tracker.scores_ref();
         let pool_size = {
-            let s = store.blocking_lock();
+            let s = store.lock().await;
             let backend_count = s.list_backends().map(|b| b.len()).unwrap_or(0);
             lorica::proxy_wiring::compute_pool_size(backend_count)
         };

--- a/lorica/src/main.rs
+++ b/lorica/src/main.rs
@@ -1573,8 +1573,14 @@ fn run_worker(
         lorica_api::acme::AcmeChallengeStore::with_db_path(db_path.clone()),
     );
 
+    let pool_size = {
+        let backend_count = store.blocking_lock().list_backends().map(|b| b.len()).unwrap_or(0);
+        lorica::proxy_wiring::compute_pool_size(backend_count)
+    };
+    info!(pool_size, "upstream keepalive pool size");
     let server_conf = Arc::new(lorica_core::server::configuration::ServerConf {
         upstream_crl_file: upstream_crl_file.map(|s| s.to_string()),
+        upstream_keepalive_pool_size: pool_size,
         ..Default::default()
     });
     let mut proxy_service = lorica_proxy::http_proxy_service(&server_conf, lorica_proxy);
@@ -1805,8 +1811,15 @@ fn run_single_process(cli: Cli) {
         let proxy_cache_misses = Arc::clone(&lorica_proxy.cache_misses);
         let proxy_ban_list = Arc::clone(&lorica_proxy.ban_list);
         let proxy_ewma_scores = lorica_proxy.ewma_tracker.scores_ref();
+        let pool_size = {
+            let s = store.blocking_lock();
+            let backend_count = s.list_backends().map(|b| b.len()).unwrap_or(0);
+            lorica::proxy_wiring::compute_pool_size(backend_count)
+        };
+        info!(pool_size, "upstream keepalive pool size");
         let server_conf = Arc::new(lorica_core::server::configuration::ServerConf {
             upstream_crl_file: cli.upstream_crl_file.clone(),
+            upstream_keepalive_pool_size: pool_size,
             ..Default::default()
         });
         let mut proxy_service = lorica_proxy::http_proxy_service(&server_conf, lorica_proxy);

--- a/lorica/src/main.rs
+++ b/lorica/src/main.rs
@@ -353,13 +353,11 @@ fn run_supervisor(cli: Cli) {
             let _ = std::fs::set_permissions(&log_sock_path, std::fs::Permissions::from_mode(0o660));
         }
         let log_sink = Arc::clone(&log_buffer);
-        let log_store_sink = log_store.clone();
         tokio::spawn(async move {
             loop {
                 match log_listener.accept().await {
                     Ok((stream, _)) => {
                         let sink = Arc::clone(&log_sink);
-                        let store_sink = log_store_sink.clone();
                         tokio::spawn(async move {
                             let mut reader = tokio::io::BufReader::new(stream);
                             let mut line = String::new();
@@ -369,11 +367,9 @@ fn run_supervisor(cli: Cli) {
                                     Ok(0) => break, // EOF - worker disconnected
                                     Ok(_) => {
                                         if let Ok(entry) = serde_json::from_str::<lorica_api::logs::LogEntry>(&line) {
-                                            if let Some(ref s) = store_sink {
-                                                if let Err(e) = s.insert(&entry) {
-                                                    tracing::warn!(error = %e, "failed to persist access log entry");
-                                                }
-                                            }
+                                            // Workers persist access logs directly via their own
+                                            // LogStore, so we only push to the in-memory buffer
+                                            // here (for WebSocket streaming to the dashboard).
                                             sink.push(entry).await;
                                         }
                                     }

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -551,6 +551,8 @@ pub struct RequestCtx {
     pub waf_detected: bool,
     /// Snapshot of the matched route for use in later pipeline stages.
     pub route_snapshot: Option<Route>,
+    /// Unique request identifier for tracing (propagated to backend via X-Request-Id).
+    pub request_id: String,
     /// Whether access logging is enabled for this route.
     pub access_log_enabled: bool,
     /// Client IP address (from socket or X-Forwarded-For).
@@ -667,6 +669,24 @@ impl LoricaProxy {
 /// Extract the request host from the Host header, falling back to URI authority.
 /// HTTP/2 uses :authority pseudo-header which pingora maps to the URI authority,
 /// while the Host header may be absent.
+/// Generate a compact hex request ID (16 bytes = 32 hex chars).
+fn generate_request_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+    let rand: u64 = {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        ts.hash(&mut h);
+        std::thread::current().id().hash(&mut h);
+        h.finish()
+    };
+    format!("{ts:016x}{rand:016x}")
+}
+
 fn extract_host(req: &lorica_http::RequestHeader) -> &str {
     req.headers
         .get("host")
@@ -690,6 +710,7 @@ impl ProxyHttp for LoricaProxy {
             waf_detected: false,
             route_snapshot: None,
             path_rewrite_regex: None,
+            request_id: generate_request_id(),
             access_log_enabled: true,
             client_ip: None,
             is_xff: false,
@@ -1699,6 +1720,9 @@ impl ProxyHttp for LoricaProxy {
             None => return Ok(()),
         };
 
+        // Inject X-Request-Id for end-to-end tracing
+        let _ = upstream_request.insert_header("X-Request-Id", &ctx.request_id);
+
         // Path rewriting: strip prefix then add prefix
         let original_path = upstream_request.uri.path().to_string();
         let query = upstream_request
@@ -2024,6 +2048,7 @@ impl ProxyHttp for LoricaProxy {
                 is_xff: ctx.is_xff,
                 xff_proxy_ip: ctx.xff_proxy_ip.as_deref().unwrap_or("").to_string(),
                 source: ctx.source.clone(),
+                request_id: ctx.request_id.clone(),
             };
             if let Some(ref store) = self.log_store {
                 if let Err(e) = store.insert(&entry) {

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -851,7 +851,7 @@ impl ProxyHttp for LoricaProxy {
                         matched_value: ip.to_string(),
                         timestamp: chrono::Utc::now().to_rfc3339(),
                         client_ip: ip.to_string(),
-                        route_hostname: req.headers.get("host").and_then(|v| v.to_str().ok()).unwrap_or("-").to_string(),
+                        route_hostname: { let h = extract_host(req); if h.is_empty() { "-" } else { h } }.to_string(),
                         action: "blocked".to_string(),
                     };
                     let _ = store.insert_waf_event(&ev);

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -491,6 +491,99 @@ impl EwmaTracker {
     }
 }
 
+/// Per-backend circuit breaker.
+///
+/// Tracks consecutive failures per backend. When the failure count reaches the
+/// threshold, the circuit opens and all traffic is redirected to other backends
+/// for a cooldown period. After the cooldown, one probe request is allowed
+/// through (half-open). If it succeeds the circuit closes; if it fails the
+/// circuit re-opens.
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    /// Per-backend state: (consecutive_failures, state, last_state_change)
+    states: dashmap::DashMap<String, CircuitBreakerState>,
+    /// Number of consecutive errors before opening the circuit.
+    threshold: u32,
+    /// How long the circuit stays open before moving to half-open (seconds).
+    cooldown_s: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CircuitBreakerState {
+    failures: u32,
+    state: CircuitStatus,
+    changed_at: Instant,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum CircuitStatus {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+impl CircuitBreaker {
+    pub fn new(threshold: u32, cooldown_s: u64) -> Self {
+        Self {
+            states: dashmap::DashMap::new(),
+            threshold,
+            cooldown_s,
+        }
+    }
+
+    /// Check if a backend is available (not in Open state).
+    /// Open circuits that have exceeded the cooldown move to HalfOpen.
+    pub fn is_available(&self, addr: &str) -> bool {
+        let mut entry = match self.states.get_mut(addr) {
+            Some(e) => e,
+            None => return true, // no state = closed = available
+        };
+        match entry.state {
+            CircuitStatus::Closed | CircuitStatus::HalfOpen => true,
+            CircuitStatus::Open => {
+                if entry.changed_at.elapsed() >= Duration::from_secs(self.cooldown_s) {
+                    entry.state = CircuitStatus::HalfOpen;
+                    entry.changed_at = Instant::now();
+                    true // allow one probe request
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Record a successful response. Resets the failure count and closes the circuit.
+    pub fn record_success(&self, addr: &str) {
+        if let Some(mut entry) = self.states.get_mut(addr) {
+            if entry.failures > 0 || entry.state != CircuitStatus::Closed {
+                entry.failures = 0;
+                entry.state = CircuitStatus::Closed;
+                entry.changed_at = Instant::now();
+            }
+        }
+    }
+
+    /// Record a failure. Increments the counter and opens the circuit if threshold is reached.
+    pub fn record_failure(&self, addr: &str) {
+        let mut entry = self.states.entry(addr.to_string()).or_insert(CircuitBreakerState {
+            failures: 0,
+            state: CircuitStatus::Closed,
+            changed_at: Instant::now(),
+        });
+        entry.failures += 1;
+        if entry.failures >= self.threshold && entry.state != CircuitStatus::Open {
+            entry.state = CircuitStatus::Open;
+            entry.changed_at = Instant::now();
+            tracing::warn!(
+                backend = %addr,
+                failures = entry.failures,
+                cooldown_s = self.cooldown_s,
+                "circuit breaker opened - backend removed from rotation"
+            );
+        }
+    }
+}
+
 /// Check whether an IP address matches a pattern (exact or CIDR prefix).
 fn ip_matches(ip: &str, pattern: &str) -> bool {
     if pattern.contains('/') {
@@ -627,6 +720,8 @@ pub struct LoricaProxy {
     pub alert_sender: Option<lorica_notify::AlertSender>,
     /// Persistent access log store (SQLite).
     pub log_store: Option<Arc<lorica_api::log_store::LogStore>>,
+    /// Per-backend circuit breaker (opens after consecutive failures).
+    pub circuit_breaker: Arc<CircuitBreaker>,
 }
 
 impl LoricaProxy {
@@ -657,6 +752,7 @@ impl LoricaProxy {
             acme_challenge_store: None,
             alert_sender: None,
             log_store: None,
+            circuit_breaker: Arc::new(CircuitBreaker::new(5, 10)),
         }
     }
 
@@ -1632,7 +1728,9 @@ impl ProxyHttp for LoricaProxy {
         let healthy_backends: Vec<&Backend> = backends_source
             .iter()
             .filter(|b| {
-                b.health_status != HealthStatus::Down && b.lifecycle_state == LifecycleState::Normal
+                b.health_status != HealthStatus::Down
+                    && b.lifecycle_state == LifecycleState::Normal
+                    && self.circuit_breaker.is_available(&b.address)
             })
             .collect();
 
@@ -2039,6 +2137,13 @@ impl ProxyHttp for LoricaProxy {
         if let Some(ref addr) = ctx.backend_addr {
             self.active_connections.fetch_sub(1, Ordering::Relaxed);
             self.backend_connections.decrement(addr);
+
+            // Update circuit breaker: 5xx or connection error = failure, else success
+            if e.is_some() || status >= 500 {
+                self.circuit_breaker.record_failure(addr);
+            } else {
+                self.circuit_breaker.record_success(addr);
+            }
         }
 
         // Push to the in-memory log buffer for dashboard viewing (if enabled)

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -584,6 +584,17 @@ impl CircuitBreaker {
     }
 }
 
+/// Compute the upstream keepalive pool size based on the number of backends.
+/// - <= 15 backends: 128 (Pingora default)
+/// - 16+ backends: 8 connections per backend, capped at 1024
+pub fn compute_pool_size(backend_count: usize) -> usize {
+    if backend_count <= 15 {
+        128
+    } else {
+        (backend_count * 8).min(1024)
+    }
+}
+
 /// Check whether an IP address matches a pattern (exact or CIDR prefix).
 fn ip_matches(ip: &str, pattern: &str) -> bool {
     if pattern.contains('/') {

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -685,6 +685,8 @@ pub struct RequestCtx {
     pub body_bytes_received: u64,
     /// Buffered request body for WAF body scanning (only when WAF is enabled).
     pub waf_body_buffer: Option<Vec<u8>>,
+    /// Backend ID for sticky session cookie injection (set in upstream_peer).
+    pub sticky_backend_id: Option<String>,
 }
 
 /// The Lorica ProxyHttp implementation that routes traffic based on database configuration.
@@ -776,6 +778,14 @@ impl LoricaProxy {
 /// Extract the request host from the Host header, falling back to URI authority.
 /// HTTP/2 uses :authority pseudo-header which pingora maps to the URI authority,
 /// while the Host header may be absent.
+/// Extract the LORICA_SRV backend ID from a Cookie header value.
+fn extract_sticky_backend(cookie_header: &str) -> Option<&str> {
+    cookie_header.split(';').find_map(|c| {
+        let c = c.trim();
+        c.strip_prefix("LORICA_SRV=")
+    })
+}
+
 /// Generate a compact hex request ID (16 bytes = 32 hex chars).
 fn generate_request_id() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -830,6 +840,7 @@ impl ProxyHttp for LoricaProxy {
             block_reason: None,
             body_bytes_received: 0,
             waf_body_buffer: None,
+            sticky_backend_id: None,
         }
     }
 
@@ -1755,9 +1766,29 @@ impl ProxyHttp for LoricaProxy {
             );
         }
 
+        // Sticky session: if enabled, try to route to the backend from the cookie
+        let sticky_backend_idx = if entry.route.sticky_session {
+            session
+                .req_header()
+                .headers
+                .get("cookie")
+                .and_then(|v| v.to_str().ok())
+                .and_then(extract_sticky_backend)
+                .and_then(|backend_id| {
+                    healthy_backends
+                        .iter()
+                        .position(|b| b.id == backend_id)
+                })
+        } else {
+            None
+        };
+
         // Backend selection based on load balancing algorithm
         use lorica_config::models::LoadBalancing;
-        let idx = match entry.route.load_balancing {
+        let idx = if let Some(sticky_idx) = sticky_backend_idx {
+            sticky_idx
+        } else {
+        match entry.route.load_balancing {
             LoadBalancing::PeakEwma => self.ewma_tracker.select_best(&healthy_backends),
             LoadBalancing::Random => {
                 use std::collections::hash_map::DefaultHasher;
@@ -1774,8 +1805,14 @@ impl ProxyHttp for LoricaProxy {
                     .collect();
                 entry.wrr_state.next(&bw)
             }
+        }
         };
         let backend = healthy_backends[idx];
+
+        // Set sticky session cookie if enabled and no existing cookie matched
+        if entry.route.sticky_session && sticky_backend_idx.is_none() {
+            ctx.sticky_backend_id = Some(backend.id.clone());
+        }
 
         ctx.backend_addr = Some(backend.address.clone());
         self.active_connections.fetch_add(1, Ordering::Relaxed);
@@ -2066,6 +2103,12 @@ impl ProxyHttp for LoricaProxy {
             let _ = upstream_response.insert_header(name, value);
         }
 
+        // Inject sticky session cookie
+        if let Some(ref backend_id) = ctx.sticky_backend_id {
+            let cookie = format!("LORICA_SRV={backend_id}; Path=/; HttpOnly; SameSite=Lax");
+            let _ = upstream_response.append_header("Set-Cookie", &cookie);
+        }
+
         Ok(())
     }
 
@@ -2297,6 +2340,7 @@ mod tests {
             auto_ban_duration_s: 3600,
             path_rules: vec![],
             return_status: None,
+            sticky_session: false,
             created_at: now,
             updated_at: now,
         }
@@ -3320,5 +3364,36 @@ mod tests {
         let config = ProxyConfig::from_store(vec![], vec![], vec![], vec![], ProxyConfigGlobals { trusted_proxy_cidrs: cidrs, ..Default::default() });
         // Only the valid CIDR and the valid bare IP should be parsed
         assert_eq!(config.trusted_proxies.len(), 2);
+    }
+
+    // ---- Sticky sessions ----
+
+    #[test]
+    fn test_extract_sticky_backend_single_cookie() {
+        assert_eq!(
+            extract_sticky_backend("LORICA_SRV=abc-123"),
+            Some("abc-123")
+        );
+    }
+
+    #[test]
+    fn test_extract_sticky_backend_multiple_cookies() {
+        assert_eq!(
+            extract_sticky_backend("session=xyz; LORICA_SRV=backend-42; lang=en"),
+            Some("backend-42")
+        );
+    }
+
+    #[test]
+    fn test_extract_sticky_backend_absent() {
+        assert_eq!(
+            extract_sticky_backend("session=xyz; lang=en"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_sticky_backend_empty() {
+        assert_eq!(extract_sticky_backend(""), None);
     }
 }

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -1801,6 +1801,16 @@ impl ProxyHttp for LoricaProxy {
         peer.options.read_timeout = Some(Duration::from_secs(entry.route.read_timeout_s as u64));
         peer.options.write_timeout = Some(Duration::from_secs(entry.route.send_timeout_s as u64));
 
+        // Drop idle pooled connections after 60s to avoid stale/half-closed TCP
+        peer.options.idle_timeout = Some(Duration::from_secs(60));
+
+        // TCP keepalive: detect dead connections in the pool before reuse
+        peer.options.tcp_keepalive = Some(lorica_core::protocols::TcpKeepalive {
+            idle: Duration::from_secs(15),
+            interval: Duration::from_secs(5),
+            count: 3,
+        });
+
         Ok(peer)
     }
 

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -167,6 +167,8 @@ pub struct ProxyConfig {
     /// client IP matches one of these will X-Forwarded-For be used for the
     /// real client IP. Empty = trust no XFF (secure default).
     pub trusted_proxies: Vec<ipnet::IpNet>,
+    /// Parsed CIDR ranges of IPs that bypass WAF, rate limiting, and auto-ban.
+    pub waf_whitelist: Vec<ipnet::IpNet>,
 }
 
 /// Global settings extracted from the config store for ProxyConfig construction.
@@ -178,6 +180,7 @@ pub struct ProxyConfigGlobals {
     pub waf_ban_threshold: u32,
     pub waf_ban_duration_s: u32,
     pub trusted_proxy_cidrs: Vec<String>,
+    pub waf_whitelist_cidrs: Vec<String>,
 }
 
 impl ProxyConfig {
@@ -200,6 +203,7 @@ impl ProxyConfig {
             waf_ban_threshold,
             waf_ban_duration_s,
             trusted_proxy_cidrs,
+            waf_whitelist_cidrs,
         } = globals;
         let backend_map: HashMap<String, Backend> = backends
             .into_iter()
@@ -354,6 +358,25 @@ impl ProxyConfig {
             })
             .collect();
 
+        // Parse WAF whitelist CIDRs (same logic as trusted proxies)
+        let waf_whitelist: Vec<ipnet::IpNet> = waf_whitelist_cidrs
+            .iter()
+            .filter_map(|s| {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    return None;
+                }
+                if let Ok(net) = trimmed.parse::<ipnet::IpNet>() {
+                    Some(net)
+                } else if let Ok(ip) = trimmed.parse::<std::net::IpAddr>() {
+                    Some(ipnet::IpNet::from(ip))
+                } else {
+                    warn!(entry = %trimmed, "ignoring invalid waf_whitelist_ips entry");
+                    None
+                }
+            })
+            .collect();
+
         ProxyConfig {
             routes_by_host,
             wildcard_routes,
@@ -363,6 +386,7 @@ impl ProxyConfig {
             waf_ban_threshold,
             waf_ban_duration_s,
             trusted_proxies,
+            waf_whitelist,
         }
     }
 
@@ -767,8 +791,19 @@ impl ProxyHttp for LoricaProxy {
             .unwrap_or("")
             .to_string();
 
-        // Ban list check (before any other processing for banned IPs)
-        if let Some(ref ip) = check_ip {
+        // Global WAF whitelist: IPs in this list bypass ban checks, IP blocklist,
+        // rate limiting, and WAF evaluation entirely.
+        let is_whitelisted = check_ip.as_ref().is_some_and(|ip| {
+            if let Ok(addr) = ip.parse::<std::net::IpAddr>() {
+                config.waf_whitelist.iter().any(|net| net.contains(&addr))
+            } else {
+                false
+            }
+        });
+
+        // Ban list + IP blocklist checks (skipped for whitelisted IPs)
+        if !is_whitelisted {
+          if let Some(ref ip) = check_ip {
             let banned = if let Some(entry) = self.ban_list.get(ip) {
                 let (banned_at, duration_s) = entry.value();
                 if banned_at.elapsed() >= Duration::from_secs(*duration_s) {
@@ -790,9 +825,7 @@ impl ProxyHttp for LoricaProxy {
                     .await?;
                 return Ok(true);
             }
-        }
 
-        if let Some(ref ip) = check_ip {
             if self.waf_engine.ip_blocklist().is_blocked_str(ip) {
                 warn!(
                     ip = %ip,
@@ -830,6 +863,7 @@ impl ProxyHttp for LoricaProxy {
                 return Ok(true);
             }
         }
+        } // end if !is_whitelisted (ban + blocklist)
 
         let host_raw = extract_host(req);
         let host = host_raw.split(':').next().unwrap_or(host_raw);
@@ -1057,8 +1091,9 @@ impl ProxyHttp for LoricaProxy {
             }
         }
 
-        // Per-route rate limiting
-        if let Some(rps) = entry.route.rate_limit_rps {
+        // Per-route rate limiting (skipped for whitelisted IPs)
+        if !is_whitelisted {
+          if let Some(rps) = entry.route.rate_limit_rps {
             if let Some(ref ip) = check_ip {
                 let key = format!("{}:{}", entry.route.id, ip);
                 self.rate_limiter.observe(&key, 1);
@@ -1135,9 +1170,10 @@ impl ProxyHttp for LoricaProxy {
                 }
             }
         }
+        } // end if !is_whitelisted (rate limiting)
 
-        // Skip WAF evaluation entirely if not enabled (zero overhead)
-        if !entry.route.waf_enabled {
+        // Skip WAF evaluation entirely if not enabled or IP is whitelisted (zero overhead)
+        if is_whitelisted || !entry.route.waf_enabled {
             return Ok(false);
         }
 
@@ -2007,11 +2043,12 @@ impl ProxyHttp for LoricaProxy {
             .or_insert_with(|| AtomicU64::new(0))
             .fetch_add(1, Ordering::Relaxed);
 
-        // Record SLA metrics for passive monitoring
-        // Exclude WebSocket upgrades (status 101) as their connection duration
-        // is not representative of HTTP request latency
+        // Record SLA metrics for passive monitoring.
+        // Exclude WebSocket upgrades (status 101) and proxy-level rejections
+        // (WAF blocks, bans, rate limits, return_status) as their latency is
+        // not representative of backend performance.
         if let Some(ref route_id) = ctx.route_id {
-            if status != 101 {
+            if status != 101 && ctx.block_reason.is_none() && !ctx.waf_blocked {
                 self.sla_collector.record(route_id, status, latency_ms);
             }
         }

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -2044,11 +2044,16 @@ impl ProxyHttp for LoricaProxy {
             .fetch_add(1, Ordering::Relaxed);
 
         // Record SLA metrics for passive monitoring.
-        // Exclude WebSocket upgrades (status 101) and proxy-level rejections
-        // (WAF blocks, bans, rate limits, return_status) as their latency is
-        // not representative of backend performance.
+        // Exclude WebSocket upgrades (status 101), proxy-level rejections
+        // (WAF blocks, bans, rate limits, return_status), and connection
+        // errors (downstream/upstream resets, timeouts) as their latency
+        // is not representative of backend performance.
         if let Some(ref route_id) = ctx.route_id {
-            if status != 101 && ctx.block_reason.is_none() && !ctx.waf_blocked {
+            if status != 101
+                && ctx.block_reason.is_none()
+                && !ctx.waf_blocked
+                && e.is_none()
+            {
                 self.sla_collector.record(route_id, status, latency_ms);
             }
         }

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -1994,7 +1994,16 @@ impl ProxyHttp for LoricaProxy {
         } else if ctx.waf_detected {
             Some("WAF detected".to_string())
         } else {
-            e.map(|err| err.to_string())
+            e.and_then(|err| {
+                let msg = err.to_string();
+                // Client disconnects (H2 stream reset, connection close) are not
+                // server errors. Status 0 already signals the incomplete response.
+                if msg.contains("not a result of an error") || msg.contains("Client closed") {
+                    None
+                } else {
+                    Some(msg)
+                }
+            })
         };
         let latency_ms = elapsed.as_millis() as u64;
 

--- a/lorica/src/proxy_wiring.rs
+++ b/lorica/src/proxy_wiring.rs
@@ -1820,6 +1820,8 @@ impl ProxyHttp for LoricaProxy {
             idle: Duration::from_secs(15),
             interval: Duration::from_secs(5),
             count: 3,
+            #[cfg(target_os = "linux")]
+            user_timeout: Duration::from_secs(0),
         });
 
         Ok(peer)

--- a/lorica/src/reload.rs
+++ b/lorica/src/reload.rs
@@ -59,6 +59,10 @@ pub async fn reload_proxy_config(
         .as_ref()
         .map(|s| s.trusted_proxies.clone())
         .unwrap_or_default();
+    let waf_whitelist_ips = settings
+        .as_ref()
+        .map(|s| s.waf_whitelist_ips.clone())
+        .unwrap_or_default();
 
     let links: Vec<(String, String)> = route_backends
         .into_iter()
@@ -77,6 +81,7 @@ pub async fn reload_proxy_config(
             waf_ban_threshold,
             waf_ban_duration_s,
             trusted_proxy_cidrs: trusted_proxies,
+            waf_whitelist_cidrs: waf_whitelist_ips,
         },
     );
 

--- a/lorica/tests/proxy_config_test.rs
+++ b/lorica/tests/proxy_config_test.rs
@@ -68,6 +68,7 @@ fn make_route(id: &str, hostname: &str, path_prefix: &str, enabled: bool) -> Rou
         auto_ban_duration_s: 3600,
         path_rules: vec![],
         return_status: None,
+            sticky_session: false,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     }

--- a/lorica/tests/proxy_routing_test.rs
+++ b/lorica/tests/proxy_routing_test.rs
@@ -66,6 +66,7 @@ fn make_route(id: &str, hostname: &str, path_prefix: &str) -> Route {
         auto_ban_duration_s: 3600,
         path_rules: vec![],
         return_status: None,
+            sticky_session: false,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     }

--- a/tests-e2e-docker/test-runner/run-tests.sh
+++ b/tests-e2e-docker/test-runner/run-tests.sh
@@ -3422,9 +3422,70 @@ if [ -n "$SESSION" ]; then
     api_del "/api/v1/backends/$RND_B2_ID" >/dev/null 2>&1 || true
 
 # =============================================================================
-# 65. CLEANUP
+# 66. STICKY SESSIONS
 # =============================================================================
-    log "=== 65. Cleanup ==="
+    log "=== 66. Sticky Sessions ==="
+
+    # Use existing healthy backend (B1_ID from section 4)
+    STICKY_BACKEND_ID="$B1_ID"
+    if [ -n "$STICKY_BACKEND_ID" ]; then
+        ok "Using existing backend for sticky test"
+        STICKY_ROUTE=$(api_post "/api/v1/routes" '{"hostname":"sticky.test","path_prefix":"/","backend_ids":["'"$STICKY_BACKEND_ID"'"],"sticky_session":true}')
+        STICKY_ROUTE_ID=$(echo "$STICKY_ROUTE" | jq -r '.data.id // empty')
+        if [ -n "$STICKY_ROUTE_ID" ]; then
+            ok "Sticky route created"
+
+            STICKY_GET=$(api_get "/api/v1/routes/$STICKY_ROUTE_ID")
+            STICKY_VAL=$(echo "$STICKY_GET" | jq -r '.data.sticky_session // empty')
+            if [ "$STICKY_VAL" = "true" ]; then
+                ok "sticky_session persisted as true"
+            else
+                fail "sticky_session not persisted (got: $STICKY_VAL)"
+            fi
+
+            sleep 12  # wait for health check (default 10s interval) + config reload
+            STICKY_RESP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -H "Host: sticky.test" "$PROXY/" 2>/dev/null || true)
+            log "Sticky proxy status: $STICKY_RESP_STATUS"
+            STICKY_HEADERS=$(curl -s -D - -o /dev/null -H "Host: sticky.test" "$PROXY/" 2>/dev/null || true)
+            if echo "$STICKY_HEADERS" | grep -qi "LORICA_SRV="; then
+                ok "LORICA_SRV cookie present in response"
+                SRV_COOKIE=$(echo "$STICKY_HEADERS" | grep -i "Set-Cookie.*LORICA_SRV" | sed 's/.*LORICA_SRV=//;s/;.*//' | tr -d '\r')
+                if [ -n "$SRV_COOKIE" ]; then
+                    ok "Cookie contains backend ID"
+                    STICKY_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -H "Host: sticky.test" -b "LORICA_SRV=$SRV_COOKIE" "$PROXY/" 2>/dev/null || true)
+                    if [ "$STICKY_STATUS" = "200" ]; then
+                        ok "Request with sticky cookie succeeds"
+                    else
+                        fail "Request with sticky cookie failed (status: $STICKY_STATUS)"
+                    fi
+                else
+                    fail "LORICA_SRV cookie value is empty"
+                fi
+            else
+                fail "LORICA_SRV cookie missing from response"
+            fi
+
+            api_put "/api/v1/routes/$STICKY_ROUTE_ID" '{"sticky_session":false}' > /dev/null
+            sleep 1
+            NOSTICKY_HEADERS=$(curl -s -D - -o /dev/null -H "Host: sticky.test" "$PROXY/" 2>/dev/null || true)
+            if echo "$NOSTICKY_HEADERS" | grep -qi "LORICA_SRV="; then
+                fail "Cookie still present after disabling sticky"
+            else
+                ok "No cookie after disabling sticky_session"
+            fi
+
+            api_del "/api/v1/routes/$STICKY_ROUTE_ID" > /dev/null
+        else
+            fail "Failed to create sticky route"
+        fi
+    else
+        fail "Failed to create sticky backend"
+    fi
+
+# =============================================================================
+# 67. CLEANUP
+# =============================================================================
+    log "=== 67. Cleanup ==="
 
     api_del "/api/v1/routes/$R1_ID" >/dev/null && ok "Route 1 deleted" || fail "Route 1 delete failed"
     api_del "/api/v1/routes/$R2_ID" >/dev/null && ok "Route 2 deleted" || fail "Route 2 delete failed"


### PR DESCRIPTION
## Summary

Lorica v1.1.0 - Major feature and resilience update based on production feedback.

### New Features

- **Sticky sessions** - Cookie-based session affinity per route. `LORICA_SRV` cookie contains backend ID (no IP leak). Configurable via dashboard or API. Falls back to normal load balancing if backend is down
- **Global WAF whitelist IPs** - IPs/CIDRs that bypass WAF, rate limiting, IP blocklist, and auto-ban entirely. Prevents operators from being auto-banned by false positives
- **12 new WAF rules** (49 total) - SQLi auth bypass, info schema recon, encoding evasion, NoSQL/MongoDB injection, XSS eval/base64, backup file access, PowerShell/Windows commands, HTTP request smuggling, scanner detection, PHP/Java deserialization, HTTP method abuse
- **X-Request-Id** - Unique request ID generated per request, propagated to backends via header, persisted in access logs and CSV export for end-to-end tracing
- **Circuit breaker** - Per-backend failure tracking. After 5 consecutive errors (5xx/connection), backend is removed from rotation for 10s. Half-open probe before recovery
- **CLI unban** - `lorica unban <IP> --password <PASSWORD>` for emergency IP removal when locked out of the dashboard
- **Access logs** - Configurable entry limit (100/500/1K/5K/10K), "X of Y entries" total count, client IP filter for forensics

### Resilience Improvements

- **TCP keepalive** on upstream connections (idle 15s, interval 5s, 3 probes) to detect stale/half-closed pooled connections
- **Upstream idle timeout** (60s) evicts stale connections from the pool
- **Upstream pool auto-sizing** at startup: 128 for <=15 backends, scales to 8 per backend up to 1024 max

### Bug Fixes

- **Duplicate access logs** in worker mode: workers now persist directly, supervisor only pushes to in-memory buffer for WebSocket streaming
- **WAF body scan false positives**: path traversal (930xxx) and protocol violation (920xxx) rules skipped during body scanning. Prevents false positives on CMS content
- **SLA metrics polluted**: WAF blocks, bans, rate limits, return_status, and connection errors (resets, timeouts) excluded from SLA latency percentiles
- **SLA breach notifications** not firing in worker mode: supervisor now checks thresholds on every flush cycle
- **SLA buckets** show date and sort most recent first
- **Access logs** WebSocket toggle: disabling auto-refresh now properly disconnects WebSocket, choice persisted in localStorage
- **Access logs** total count: WebSocket messages no longer reset the total count
- **IP blocklist** WAF events showing `-` as route: now falls back to URI authority
- **H2 disconnect noise**: "Client closed H2, not a result of an error" suppressed from Error column (status 0 is sufficient)
- **WAF category labels**: added SSRF, XXE, SSTI, Log4Shell, IP Blocklist, Prototype Pollution to Security page labels and event filter
- **Settings modals**: CSS styles migrated to global app.css for DNS Provider and Notification Channel sub-components
- **Migration fix**: sticky_session column added unconditionally (not tied to migration version) for upgrade compatibility

### Documentation

- Technical backlog updated with feature roadmap (12 items from competitive analysis)

## Test plan

- [x] 494 Rust unit tests passing (clippy clean)
- [x] 119 frontend Vitest tests passing
- [x] 288 E2E Docker assertions passing (including 8 sticky session tests)
- [x] Deployed and validated on production (6-worker mode)
- [x] Verify sticky sessions with multi-backend route
- [x] Verify WAF whitelist bypass with operator IP
- [x] Verify circuit breaker triggers on backend failure
- [x] Verify X-Request-Id appears in backend logs
