### PR TITLE
v1.5.11: close the two Story 8.1 spawn asymmetries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Author: Rwx-G
 
 - Cron-scheduled load tests now run in supervisor/worker mode: the supervisor created a `LoadTestEngine` for the management API but never started the cron scheduler, so scheduled load tests silently never executed outside single-process mode. Both API-serving modes now go through one shared `startup::start_load_test_engine` helper that creates the engine and starts the scheduler together, making the asymmetry unrepresentable (Epic 8 Story 8.1 finding).
 - Notification-channel edits hot-reload in single-process mode: the config-reload listener now rebuilds the notification dispatcher from the persisted channel configs on every reload signal, mirroring supervisor mode. Previously single-process deployments kept dispatching alerts to the boot-time channel list until restart (Epic 8 Story 8.1 finding).
+- The e2e suite teardown now passes every compose profile to `down -v`, so profile-gated containers and volumes (workers, cert-export, smoke profiles) no longer survive a run and leak stale state into the next one (Epic 8 Story 8.1 finding, extended to all seven current profiles).
 
 ## [1.5.10] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Author: Rwx-G
 
 ## [Unreleased]
 
+## [1.5.11] - 2026-06-10
+
 ### Fixed
 
 - Cron-scheduled load tests now run in supervisor/worker mode: the supervisor created a `LoadTestEngine` for the management API but never started the cron scheduler, so scheduled load tests silently never executed outside single-process mode. Both API-serving modes now go through one shared `startup::start_load_test_engine` helper that creates the engine and starts the scheduler together, making the asymmetry unrepresentable (Epic 8 Story 8.1 finding).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Author: Rwx-G
 
 ## [Unreleased]
 
+### Fixed
+
+- Cron-scheduled load tests now run in supervisor/worker mode: the supervisor created a `LoadTestEngine` for the management API but never started the cron scheduler, so scheduled load tests silently never executed outside single-process mode. Both API-serving modes now go through one shared `startup::start_load_test_engine` helper that creates the engine and starts the scheduler together, making the asymmetry unrepresentable (Epic 8 Story 8.1 finding).
+- Notification-channel edits hot-reload in single-process mode: the config-reload listener now rebuilds the notification dispatcher from the persisted channel configs on every reload signal, mirroring supervisor mode. Previously single-process deployments kept dispatching alerts to the boot-time channel list until restart (Epic 8 Story 8.1 finding).
+
 ## [1.5.10] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,7 +2907,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lorica"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "ammonia",
  "arc-swap",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-api"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-bench"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "chrono",
  "lorica-config",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-challenge"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-command"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "nix",
  "prost 0.13.5",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-config"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-dashboard"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "axum",
  "hyper 1.10.1",
@@ -3201,7 +3201,7 @@ version = "0.1.0"
 
 [[package]]
 name = "lorica-geoip"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-shmem"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "nix",
  "rand 0.9.4",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-worker"
-version = "1.5.10"
+version = "1.5.11"
 dependencies = [
  "nix",
  "socket2 0.5.10",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/version-1.5.10-brightgreen.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.5.11-brightgreen.svg" alt="Version">
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Platform-Linux-0078D6.svg" alt="Platform">
   <img src="https://img.shields.io/badge/Lorica%20Tests-1306%2B-brightgreen.svg" alt="Lorica Tests">

--- a/dist/rpm/lorica.spec
+++ b/dist/rpm/lorica.spec
@@ -1,5 +1,5 @@
 Name:           lorica
-Version:        1.5.10
+Version:        1.5.11
 Release:        1%{?dist}
 Summary:        Modern reverse proxy with built-in dashboard
 License:        Apache-2.0

--- a/lorica-api/Cargo.toml
+++ b/lorica-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-api"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -9,11 +9,11 @@ description = "REST API for Lorica reverse proxy management"
 
 [dependencies]
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-config = { version = "1.5.10", path = "../lorica-config" }
-lorica-dashboard = { version = "1.5.10", path = "../lorica-dashboard" }
+lorica-config = { version = "1.5.11", path = "../lorica-config" }
+lorica-dashboard = { version = "1.5.11", path = "../lorica-dashboard" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
-lorica-bench = { version = "1.5.10", path = "../lorica-bench" }
+lorica-bench = { version = "1.5.11", path = "../lorica-bench" }
 # Used in `certificates.rs::validate_certificate_bundle` to gate
 # every cert upload (POST /certificates, PUT /certificates/{id},
 # POST /config/import) with the exact loader the worker uses :

--- a/lorica-api/openapi.yaml
+++ b/lorica-api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lorica API
   description: REST API for Lorica reverse proxy management
-  version: "1.5.10"
+  version: "1.5.11"
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/lorica-bench/Cargo.toml
+++ b/lorica-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-bench"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -8,7 +8,7 @@ repository = "https://github.com/Rwx-G/Lorica"
 description = "SLA monitoring and load testing for Lorica reverse proxy"
 
 [dependencies]
-lorica-config = { version = "1.5.10", path = "../lorica-config" }
+lorica-config = { version = "1.5.11", path = "../lorica-config" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/lorica-challenge/Cargo.toml
+++ b/lorica-challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-challenge"
-version = "1.5.10"
+version = "1.5.11"
 edition = "2021"
 license = "Apache-2.0"
 description = "Bot-protection challenges (cookie + PoW + captcha) for Lorica"

--- a/lorica-command/Cargo.toml
+++ b/lorica-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-command"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/Cargo.toml
+++ b/lorica-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-config"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/Cargo.toml
+++ b/lorica-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-dashboard"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/frontend/package-lock.json
+++ b/lorica-dashboard/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/lorica-dashboard/frontend/package.json
+++ b/lorica-dashboard/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.5.10",
+  "version": "1.5.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/lorica-geoip/Cargo.toml
+++ b/lorica-geoip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-geoip"
-version = "1.5.10"
+version = "1.5.11"
 edition = "2021"
 license = "Apache-2.0"
 description = "GeoIP country-code lookup for Lorica, wrapping maxminddb"

--- a/lorica-shmem/Cargo.toml
+++ b/lorica-shmem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-shmem"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-worker/Cargo.toml
+++ b/lorica-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-worker"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica/Cargo.toml
+++ b/lorica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica"
-version = "1.5.10"
+version = "1.5.11"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -39,21 +39,21 @@ lorica-lb = { version = "0.1.0", path = "../lorica-lb", optional = true, default
 # call site explicit.
 lorica-ketama = { version = "0.1.0", path = "../lorica-ketama" }
 lorica-proxy = { version = "0.1.0", path = "../lorica-proxy", optional = true, default-features = false }
-lorica-config = { version = "1.5.10", path = "../lorica-config" }
-lorica-api = { version = "1.5.10", path = "../lorica-api" }
+lorica-config = { version = "1.5.11", path = "../lorica-config" }
+lorica-api = { version = "1.5.11", path = "../lorica-api" }
 lorica-error = { version = "0.1.0", path = "../lorica-error" }
 lorica-tls = { version = "0.1.0", path = "../lorica-tls" }
-lorica-worker = { version = "1.5.10", path = "../lorica-worker" }
-lorica-command = { version = "1.5.10", path = "../lorica-command" }
-lorica-shmem = { version = "1.5.10", path = "../lorica-shmem" }
+lorica-worker = { version = "1.5.11", path = "../lorica-worker" }
+lorica-command = { version = "1.5.11", path = "../lorica-command" }
+lorica-shmem = { version = "1.5.11", path = "../lorica-shmem" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 lorica-limits = { version = "0.1.0", path = "../lorica-limits" }
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-geoip = { version = "1.5.10", path = "../lorica-geoip" }
-lorica-challenge = { version = "1.5.10", path = "../lorica-challenge" }
+lorica-geoip = { version = "1.5.11", path = "../lorica-geoip" }
+lorica-challenge = { version = "1.5.11", path = "../lorica-challenge" }
 once_cell = { workspace = true }
-lorica-bench = { version = "1.5.10", path = "../lorica-bench" }
+lorica-bench = { version = "1.5.11", path = "../lorica-bench" }
 regex = "1"
 # HTML sanitization for operator-supplied error_page_html (v1.5.0
 # audit finding HIGH-1). Whitelist-based parser replaces the

--- a/lorica/src/startup/mod.rs
+++ b/lorica/src/startup/mod.rs
@@ -122,6 +122,22 @@ pub(crate) async fn start_alerting_stack(
     }
 }
 
+/// Create the load-test engine and start its cron scheduler.
+///
+/// One helper for both API-serving modes (Epic 8 Story 8.1 asymmetry,
+/// fixed in v1.5.11): supervisor mode used to create a `LoadTestEngine`
+/// for `AppState` but never called `start_scheduler`, so cron-scheduled
+/// load tests silently never ran outside single-process mode. Going
+/// through this helper makes "engine without scheduler" unrepresentable
+/// at the call sites.
+pub(crate) fn start_load_test_engine(
+    store: &Arc<Mutex<ConfigStore>>,
+) -> Arc<lorica_bench::LoadTestEngine> {
+    let engine = Arc::new(lorica_bench::LoadTestEngine::new());
+    lorica_bench::scheduler::start_scheduler(Arc::clone(store), Arc::clone(&engine));
+    engine
+}
+
 /// Run the shared API-server tail: session store, ACME auto-renewal,
 /// cert-expiry notifier, then the blocking `start_server` loop
 /// (audit H-9 dedup).

--- a/lorica/src/startup/single.rs
+++ b/lorica/src/startup/single.rs
@@ -223,23 +223,21 @@ pub(crate) fn run_single_process(cli: Cli) {
         // dispatcher + alert bridge + probe scheduler + SLA collector
         // cluster shared with supervisor mode (audit H-9, see
         // `startup::start_alerting_stack`). The dispatcher handle is
-        // discarded: single-process mode never rebuilds it at runtime
-        // and AppState only needs the history ring.
+        // kept: the config-reload listener below rebuilds it when
+        // notification channels change (Story 8.1 asymmetry, fixed in
+        // v1.5.11: edits used to be ignored until restart in
+        // single-process mode while supervisor mode hot-reloaded them).
         let alert_sender = lorica_notify::AlertSender::new(256);
         let startup::AlertingStack {
-            notify_dispatcher: _,
+            notify_dispatcher,
             notification_history,
             probe_scheduler,
             sla_collector,
         } = startup::start_alerting_stack(&store, &alert_sender, log_store.clone()).await;
 
-        // Create load test engine (shared between API and scheduler)
-        let load_test_engine = Arc::new(lorica_bench::LoadTestEngine::new());
-
-        // Start load test cron scheduler
-        let lt_scheduler_store = Arc::clone(&store);
-        let lt_scheduler_engine = Arc::clone(&load_test_engine);
-        lorica_bench::scheduler::start_scheduler(lt_scheduler_store, lt_scheduler_engine);
+        // Load-test engine + cron scheduler (shared helper, see
+        // `startup::start_load_test_engine`)
+        let load_test_engine = startup::start_load_test_engine(&store);
 
         // Create shared ACME challenge store backed by SQLite for cross-process access
         let acme_challenge_store =
@@ -465,6 +463,7 @@ pub(crate) fn run_single_process(cli: Cli) {
         let reload_probe_scheduler = Arc::clone(&probe_scheduler);
         let reload_connection_filter = Arc::clone(&connection_filter);
         let reload_mtls_fp = Arc::clone(&mtls_installed_fingerprint);
+        let reload_notify_dispatcher = Arc::clone(&notify_dispatcher);
         let _reload_handle = tokio::spawn(async move {
             while config_reload_rx.changed().await.is_ok() {
                 if let Err(e) = lorica::reload::reload_proxy_config_with_mtls(
@@ -482,6 +481,12 @@ pub(crate) fn run_single_process(cli: Cli) {
                 {
                     let s = reload_store.lock().await;
                     reload_sla_collector.load_configs(&s);
+                    // Rebuild notification dispatcher with updated
+                    // channel configs, mirroring supervisor mode
+                    // (Story 8.1 asymmetry, fixed in v1.5.11).
+                    let new_dispatcher = startup::build_notify_dispatcher(&s);
+                    let mut d = reload_notify_dispatcher.lock().await;
+                    *d = new_dispatcher;
                 }
             }
         });

--- a/lorica/src/startup/supervisor.rs
+++ b/lorica/src/startup/supervisor.rs
@@ -1049,6 +1049,12 @@ pub(crate) fn run_supervisor(cli: Cli) {
         // mode (audit H-9, see `startup::run_api_server`; v1.5.2 fix:
         // worker mode was missing auto-renewal entirely).
         let api_alert_sender = alert_sender.clone();
+        // Load-test engine + cron scheduler (shared helper, see
+        // `startup::start_load_test_engine`). Story 8.1 asymmetry,
+        // fixed in v1.5.11: supervisor mode used to create the engine
+        // for AppState without ever starting the scheduler, so
+        // cron-scheduled load tests silently never ran in worker mode.
+        let load_test_engine = startup::start_load_test_engine(&store);
         let api_handle = tokio::spawn(async move {
             let state = AppState {
                 store: api_store,
@@ -1067,7 +1073,7 @@ pub(crate) fn run_supervisor(cli: Cli) {
                 acme_challenge_store: Some(lorica_api::acme::AcmeChallengeStore::with_db_path(api_db_path)),
                 pending_dns_challenges: std::sync::Arc::new(dashmap::DashMap::new()),
                 sla_collector: Some(Arc::clone(&sla_collector)),
-                load_test_engine: Some(Arc::new(lorica_bench::LoadTestEngine::new())),
+                load_test_engine: Some(load_test_engine),
                 // cache/ban are per-worker process; aggregated via command channel
                 cache_hits: None,
                 cache_misses: None,

--- a/tests-e2e-docker/run.sh
+++ b/tests-e2e-docker/run.sh
@@ -32,6 +32,12 @@ if [ -n "$BUILD_FLAG" ]; then
     docker compose build
 fi
 
+# Profile-gated services need explicit --profile flags on teardown or
+# `down -v` skips their containers and named volumes; the next run then
+# boots against stale data (e.g. the cert-export smoke rotates the
+# admin password, and a stale volume 401s the next run's login).
+ALL_PROFILES="--profile bot --profile bot-workers --profile cert-export --profile geoip --profile otel --profile otel-workers --profile rdns"
+
 # ---- Phase 1: Single-process tests ----
 echo "=== Lorica E2E Tests (single-process) ==="
 echo ""
@@ -47,7 +53,7 @@ for i in $(seq 1 60); do
     if [ "$i" = "60" ]; then
         echo "ERROR: Lorica did not start within 120s"
         docker compose logs lorica | tail -20
-        docker compose down -v
+        docker compose $ALL_PROFILES down -v
         exit 1
     fi
     sleep 2
@@ -109,7 +115,7 @@ fi
 
 # Cleanup unless --keep
 if [ "$KEEP" = false ]; then
-    docker compose down -v
+    docker compose $ALL_PROFILES down -v
 fi
 
 if [ "$EXIT_CODE" = "0" ]; then


### PR DESCRIPTION
## Summary

Two real bugs identified by the Epic 8 Story 8.1 extraction on the parked `feat/v1.6.0` branch and still present on `main` after the v1.5.10 split. Fixing them in a 1.5.* patch closes Story 8.1 entirely through the shipped patches before the v1.6.0 branch is rebuilt.

- **Cron-scheduled load tests never ran in supervisor/worker mode**: the supervisor created a `LoadTestEngine` for the management API but never started the cron scheduler. Both API-serving modes now go through one shared `startup::start_load_test_engine` helper that creates the engine and starts the scheduler together, making the asymmetry unrepresentable.
- **Notification-channel edits were ignored until restart in single-process mode**: the dispatcher handle was discarded after boot while supervisor mode rebuilt it on every config reload. The single-process reload listener now rebuilds the dispatcher from the persisted channel configs, mirroring the supervisor.

## Validation
- `cargo clippy` (CI scope + `lorica --no-deps --all-targets`) clean, `cargo audit` clean, build OK (rust:1-bookworm Docker).
- `cargo test -p lorica` (unit + e2e) and `cargo test -p lorica-bench` green.
- Workspace builds at 1.5.11 with regenerated `Cargo.lock`.