### PR TITLE
fix(acme): renew certificates in place (v1.5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Author: Rwx-G
 
 ## [Unreleased]
 
+## [1.5.12] - 2026-06-16
+
+### Fixed
+
+- ACME certificate auto-renewal now updates the existing certificate in place (same id) instead of issuing a new certificate, reassigning routes, then deleting the old one. The previous insert-then-reassign design could leave the renewed certificate unbound while the route kept pointing at the old certificate, so the same domain was re-requested every cycle until Let's Encrypt rate-limited the account ("too many certificates already issued for this exact set of identifiers"). Route bindings now survive a renewal untouched, aligning with how Caddy, Traefik and certbot replace a certificate in place (2026-06-16 mail.kaliaops.com incident).
+- The auto-renewal loop no longer renews certificates that are not referenced by any route, so orphaned or duplicate certificates can no longer consume Let's Encrypt issuance quota and snowball into a rate-limit.
+- On startup, superseded orphan ACME certificates (unbound and replaced by a newer certificate for the same identifier set) are purged, clearing the duplicate rows the old renewal path accumulated. Bound and unique certificates are never touched.
+- The renewal loop now backs off on a Let's Encrypt `rateLimited` error until the returned `retry after` time instead of re-attempting every cycle.
+
+### Security
+
+- The cooldown parsed from a Let's Encrypt `retry after` response is clamped to a 7 day maximum, so a malformed or hostile ACME response cannot suspend auto-renewal long enough for the live certificate to expire.
+
 ## [1.5.11] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,7 +2907,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lorica"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "ammonia",
  "arc-swap",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-api"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-bench"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "chrono",
  "lorica-config",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-challenge"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-command"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "nix",
  "prost 0.13.5",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-config"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-dashboard"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "axum",
  "hyper 1.10.1",
@@ -3201,7 +3201,7 @@ version = "0.1.0"
 
 [[package]]
 name = "lorica-geoip"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-shmem"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "nix",
  "rand 0.9.4",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-worker"
-version = "1.5.11"
+version = "1.5.12"
 dependencies = [
  "nix",
  "socket2 0.5.10",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/version-1.5.11-brightgreen.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.5.12-brightgreen.svg" alt="Version">
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Platform-Linux-0078D6.svg" alt="Platform">
   <img src="https://img.shields.io/badge/Lorica%20Tests-1306%2B-brightgreen.svg" alt="Lorica Tests">

--- a/dist/rpm/lorica.spec
+++ b/dist/rpm/lorica.spec
@@ -1,5 +1,5 @@
 Name:           lorica
-Version:        1.5.11
+Version:        1.5.12
 Release:        1%{?dist}
 Summary:        Modern reverse proxy with built-in dashboard
 License:        Apache-2.0

--- a/docs/stories/fix-1.5.12-acme-renewal-in-place.md
+++ b/docs/stories/fix-1.5.12-acme-renewal-in-place.md
@@ -1,0 +1,274 @@
+# Fix 1.5.12 - ACME renewal in-place (stop orphaning routes and burning LE quota)
+
+Author: Romain G.
+
+Status: Review
+
+## Context
+
+Production incident (2026-06-16). For `mail.kaliaops.com` the ACME auto-renewal
+kept issuing a new certificate every day until Let's Encrypt rate-limited the
+account:
+
+```
+ACME renewal failed - existing cert still active
+domain: mail.kaliaops.com
+error: too many certificates (5) already issued for this exact set of identifiers
+       in the last 168h0m0s, retry after ... (urn:...:rateLimited)
+```
+
+Root cause confirmed from the journal and the code:
+
+1. The renewal path is `INSERT new cert (new UUID)` -> `reassign route old->new`
+   -> `delete old` (`lorica-api/src/acme/renewal.rs:151-196`,
+   `lorica-api/src/acme/http01.rs:227-269`, `dns01.rs:317-360`). The renewal
+   loop logs `routes reassigned to renewed certificate` only when the reassign
+   matched a route (`renewal.rs:163`). Every healthy domain shows that line
+   (`routes:1`); `mail.kaliaops.com` never does, i.e. its reassign matched
+   zero routes. The route stayed on the old cert.
+2. The renewal eligibility filter (`should_auto_renew`, `renewal.rs:41-54`, and
+   the loop guard `renewal.rs:95-101`) only checks `is_acme`, `acme_auto_renew`,
+   `dns01-manual`, and the expiry window. It never checks whether the cert is
+   bound to a route. Unbound duplicate certs for the same identifier set were
+   therefore renewed on every cycle; renewing an unbound cert produces another
+   unbound cert (reassign matches 0), so the served cert (bound, in-window) was
+   never replaced and stayed in the renewal window, re-firing daily.
+3. On a `rateLimited` error the loop does the correct fail-safe ("existing cert
+   still active") but ignores the `retry after` timestamp and re-attempts every
+   `check_interval`, hammering LE (attempts on Jun 11, 12, 12, 13, 14, 15, 16,
+   16).
+
+There is no `UNIQUE` constraint on `certificates` (no dedup), and the
+cert-export feature does no database writes (`lorica-api/src/cert_export.rs`),
+so "exported" is a correlation (those are the manually-managed certs that had
+accumulated duplicates), not a cause.
+
+The design itself is the fond problem: minting a fresh random id per issuance
+and then re-pointing references is what allows orphans. Caddy, Traefik and
+certbot all key a cert by its identifier set under a stable key and renew
+**in place**; they cannot orphan a route by construction.
+
+## Acceptance Criteria
+
+AC1 - In-place renewal. Renewing an existing ACME certificate updates that
+certificate row (same `id`, new pem/key/not_before/not_after/san_domains) via
+`ConfigStore::update_certificate`, instead of inserting a new row and
+reassigning routes. After a renewal:
+- the certificate keeps its `id`;
+- every route that referenced it still references it (no `reassign`, no
+  `delete`, no orphan row created);
+- the TLS resolver serves the new leaf after the normal config reload.
+Fresh issuance (no pre-existing cert) keeps inserting a new row as today.
+
+AC2 - Only renew bound certificates. The auto-renewal loop skips any
+certificate not referenced by at least one route (`routes.certificate_id`),
+using the same active-cert-id derivation as `reload_cert_resolver`
+(`lorica/src/reload.rs:828-846`). An unbound ACME cert is never auto-renewed.
+The manual renew endpoint (`POST /certificates/:id/renew`) is unchanged in
+intent but must also renew in place (AC1).
+
+AC3 - Respect Let's Encrypt rate limiting. On a `rateLimited` ACME error the
+loop records a cooldown for that certificate and does not re-attempt its
+renewal before the cooldown expires. The cooldown is taken from the error's
+`retry after <RFC stamp>` when parseable, otherwise a safe default (24h).
+Cooldown state is per-process (in-memory) for this patch; persistence across
+restarts is out of scope and noted as a follow-up. The cooldown must be logged
+at INFO when it suppresses an attempt.
+
+AC4 - Purge superseded orphan ACME certs at startup. At startup, after the
+store is open, delete ACME certificates (`is_acme = true`) that are BOTH
+unreferenced by any route AND superseded (another certificate exists for the
+same identifier set - same primary `domain` and same `san_domains` set - with a
+later `not_after`). A unique unbound cert with no newer sibling is kept (an
+operator may bind it). Each purge is logged at INFO with the count and ids. The
+purge runs in both single-process and supervisor startup paths, mirroring the
+`reexport_all` startup hook.
+
+AC5 - No regression. All existing tests pass; clippy/audit/fmt clean per the
+project gates. New behavior is covered by tests (see Testing).
+
+## Tasks / Subtasks
+
+- [x] AC1: thread an `existing_cert_id: Option<&str>` through
+  `renew_with_method` -> `provision_with_acme` / `provision_with_acme_dns`.
+  When `Some`, persist via `update_certificate` (same id); when `None`, keep
+  `create_certificate`. Return the (unchanged) cert id.
+- [x] AC1: in `renewal.rs`, the auto-renewal loop and `renew_certificate`
+  (manual) call the renewal with `Some(cert.id)`, and DROP the `reassign` +
+  `delete` block. Keep the success log and `notify_config_changed`.
+- [x] AC1: confirm `update_certificate` re-encrypts `key_pem` and updates
+  `san_domains`, `not_before`, `not_after`, `fingerprint`, `issuer`,
+  `acme_method` (it does, `certs.rs:77-107`). `created_at` stays the original.
+- [x] AC2: in the loop, build the bound-cert-id set from `list_routes()` and
+  skip certs not in it (before the expiry check). Add the same guard to
+  `should_auto_renew` is NOT possible (it lacks route context) - do it in the
+  loop and add a small pure helper `is_bound(cert_id, &route_ids)` that is
+  unit-testable.
+- [x] AC3: add an in-memory `HashMap<String /*cert id*/, DateTime<Utc>>`
+  cooldown map owned by the renewal task. Skip a cert whose cooldown is in the
+  future. On `Err`, classify `rateLimited` (string match on
+  `urn:ietf:params:acme:error:rateLimited` / "rateLimited" / "too many
+  certificates") and parse `retry after <stamp>`; set the cooldown.
+- [x] AC4: add `ConfigStore` helpers to list certs + routes (exist) and a pure
+  function `superseded_orphans(certs, route_ids) -> Vec<String>` returning ids
+  to purge; call `delete_certificate` for each at startup. Unit-test the pure
+  function.
+- [x] Version bump 1.5.11 -> 1.5.12 across `docs/BUMP-CHECKLIST.md` files.
+- [x] CHANGELOG: add `## [1.5.12]` Fixed + Security entries.
+- [x] Tests (see Testing).
+
+## Dev Notes
+
+- `provision_with_acme` / `provision_with_acme_dns` currently end with
+  `create_certificate` inside a `db_blocking`, then an awaited
+  `export_after_release`. For renewal-in-place, swap the `create_certificate`
+  for `update_certificate` when `existing_cert_id` is `Some`. The awaited export
+  stays (it is fine; it does no DB writes) but is no longer between a create and
+  a separate reassign, so it cannot interleave with a route switch.
+- Dropping `reassign`/`delete` from the renewal loop removes the only callers of
+  `reassign_certificate`. Keep `reassign_certificate` in the store (still used
+  by tests / future) but it is no longer on the renewal hot path.
+- The resolver keys by domain and serves only route-bound certs
+  (`reload.rs:842-846`), so in-place update is picked up by the existing
+  `notify_config_changed` -> reload, no extra wiring.
+- Rate-limit string: the live error is
+  `... too many certificates (5) already issued for this exact set of
+  identifiers in the last 168h0m0s, retry after 2026-06-11 06:19:40 UTC: see ...
+  (urn:ietf:params:acme:error:rateLimited)`. Parse the substring after
+  `retry after ` up to ` UTC` / `:` as `%Y-%m-%d %H:%M:%S` UTC.
+- Identifier-set equality for purge: compare primary `domain` plus the SORTED,
+  de-duplicated `san_domains` so ordering differences do not defeat the match.
+- AC4 anchor (correction): there is NO `reexport_all` startup hook;
+  `reexport_all` is an API endpoint (`lorica-api/src/routes/cert_export.rs:180`).
+  Run the purge in the shared both-modes startup tail
+  `lorica/src/startup/mod.rs::run_api_server` (around line 171, just before
+  `spawn_renewal_task`), where `state.store` exists, so single-process and
+  supervisor modes share one call site and cannot drift.
+- AC3 cooldown lives inside `spawn_renewal_task`'s async loop (owned by the
+  task, not global): declare the `HashMap` before the `loop {}` so it persists
+  across `check_interval` ticks for the lifetime of the process.
+
+## Testing
+
+- `should_auto_renew` unchanged tests still pass; add a loop-level test (or a
+  pure `is_bound` test) proving an unbound cert is skipped.
+- In-place renewal: with an in-memory store, seed a cert + a route referencing
+  it; run the renewal-store mutation with `existing_cert_id = Some(id)`; assert
+  the cert id is unchanged, the route still points to it, and
+  `list_certificates().len()` did not grow.
+- Rate-limit: a pure helper `cooldown_from_error(&str) -> Option<DateTime<Utc>>`
+  parses the retry-after; assert it parses the real message and falls back to
+  `None` (caller applies default) on garbage.
+- Purge: `superseded_orphans` returns the older unbound dup id, keeps the bound
+  one and a unique unbound one.
+
+## File List
+
+Modified:
+
+- `lorica-api/src/acme/http01.rs` - `provision_with_acme` takes
+  `existing_cert_id`, in-place update vs insert.
+- `lorica-api/src/acme/dns01.rs` - `provision_with_acme_dns` takes
+  `existing_cert_id`, in-place update vs insert.
+- `lorica-api/src/acme/renewal.rs` - `existing_cert_id` threaded through
+  `renew_with_method`; reassign + delete dropped; AC2 bound-only skip; AC3
+  cooldown map + `cooldown_from_error`; pure `is_bound` + `superseded_orphans`.
+- `lorica-api/src/acme/mod.rs` - re-export `superseded_orphans`.
+- `lorica-api/src/acme/tests.rs` - unit tests for `is_bound`,
+  `cooldown_from_error`, `superseded_orphans`.
+- `lorica/src/startup/mod.rs` - `purge_superseded_acme_orphans` helper + call in
+  the shared `run_api_server` tail (AC4).
+- `lorica-config/src/tests.rs` - in-place renewal store test (AC1).
+- `CHANGELOG.md` - `## [1.5.12]` Fixed + Security entries.
+- Version bump 1.5.11 -> 1.5.12: `lorica/Cargo.toml`, `lorica-api/Cargo.toml`,
+  `lorica-bench/Cargo.toml`, `lorica-challenge/Cargo.toml`,
+  `lorica-command/Cargo.toml`, `lorica-config/Cargo.toml`,
+  `lorica-dashboard/Cargo.toml`, `lorica-geoip/Cargo.toml`,
+  `lorica-shmem/Cargo.toml`, `lorica-worker/Cargo.toml`,
+  `lorica-api/openapi.yaml`, `lorica-dashboard/frontend/package.json`,
+  `lorica-dashboard/frontend/package-lock.json`, `dist/rpm/lorica.spec`,
+  `README.md`.
+
+## Dev Agent Record
+
+### Completion Notes
+
+- AC1: `provision_with_acme` (http01) and `provision_with_acme_dns` (dns01) now
+  take `existing_cert_id: Option<&str>`. `Some` -> `update_certificate` (same
+  id, route bindings untouched); `None` -> `create_certificate` with a fresh
+  UUID. `renew_with_method`, the auto-renewal loop, and the manual
+  `renew_certificate` endpoint all pass `Some(&cert.id)`. The reassign + delete
+  block is gone from both renewal paths. `created_at` is preserved because
+  `update_certificate` never writes that column.
+- AC2: the loop derives a `HashSet<String>` of route-bound cert ids from
+  `list_routes()` (same shape as `reload_cert_resolver`) and skips any cert that
+  is not bound, before the expiry checks. Pure helper `is_bound` is unit-tested.
+- AC3: a `HashMap<String, DateTime<Utc>>` cooldown map is declared before the
+  `loop {}` so it persists across ticks. A cert in cooldown is skipped with an
+  INFO log. On an `Err`, `cooldown_from_error` classifies rate-limit messages
+  (`rateLimited` / "too many certificates"), parses `retry after <stamp>`
+  (`%Y-%m-%d %H:%M:%S` UTC), and falls back to `now + 24h`. A successful renewal
+  clears the cooldown entry.
+- AC4: pure `superseded_orphans(certs, bound_ids) -> Vec<String>` lives in
+  `lorica-api/src/acme/renewal.rs` (re-exported from `acme`). Identity is the
+  primary `domain` plus the sorted, de-duplicated `san_domains`. The startup
+  helper `purge_superseded_acme_orphans` in `lorica/src/startup/mod.rs` runs
+  once in the shared `run_api_server` tail (single-process + supervisor), lists
+  certs + routes, deletes each orphan, and logs an INFO with count + ids.
+
+### Decisions / gotchas
+
+- `reassign_certificate` is kept in the store as a `pub fn`; it is now unused on
+  the renewal hot path but, being public API of `lorica-config`, it does not
+  trip `dead_code` under `-D warnings`. No test references it (the story note to
+  the contrary is stale); none was added.
+- The in-place store mutation behavior (id kept, route binding kept, no row
+  growth, `created_at` preserved) is covered by a `lorica-config` store test
+  that reuses the existing `make_route` / `make_certificate` fixtures, rather
+  than reconstructing a full `Route` literal inside `lorica-api`.
+- The manual `POST /certificates/:id/renew` response keeps its
+  `old_cert_id` + `new_cert_id` fields (now both equal to the unchanged id)
+  rather than collapsing to a single field, so the dashboard's existing
+  `renewCertificate` response type (`lorica-dashboard/frontend/src/lib/api.ts`)
+  is not broken.
+- Version bump and CHANGELOG are intentionally NOT touched in the dev pass
+  (orchestrator owns versioning).
+
+### QA review round (3 BMAD reviewers + 6 auditors)
+
+Findings actioned by the orchestrator after the multi-agent review:
+
+- `superseded_orphans` identity is now the UNION of `domain` and `san_domains`
+  (sorted, de-duplicated), not the `(domain, sans)` pair. A penetration/security
+  finding showed uploaded certs store SANs without repeating the primary, so the
+  pair-keyed version under-matched real duplicates. Also rewritten single-pass
+  (latest-`not_after`-per-identity map) to drop the O(n^2) scan and the repeated
+  clones the perf/quality auditors flagged.
+- The cooldown parsed from a Let's Encrypt `retry after` is clamped to
+  `now + 7 days` (security finding): a hostile/garbled far-future stamp can no
+  longer suspend auto-renewal until the live cert expires.
+- Extracted a pure `in_cooldown` predicate (used by the loop's skip) so AC3's
+  skip behavior is unit-testable, per the test-adequacy finding. Added a
+  per-tick `retain` sweep of expired cooldown entries so the map stays bounded.
+- Added tests: `in_cooldown` (future/expired/absent), cooldown clamp, garbage
+  stamp -> 24h fallback, `superseded_orphans` `not_after` tie (both kept), and
+  primary-absent-from-SAN identity match.
+
+Findings consciously NOT actioned (out of scope / non-issues): inline
+`should_auto_renew` duplication and the `all_domains` dedup are pre-existing;
+purged orphans do not leave stale exported files (they share the surviving
+cert's hostname export dir); moving `superseded_orphans` into `lorica-config`
+is an optional future cleanup; the manual renew endpoint intentionally has no
+cooldown (AC3 is auto-loop only).
+
+## Change Log
+
+- 2026-06-16: Draft created (Romain G.) from the 2026-06-16 mail.kaliaops.com
+  rate-limit incident analysis.
+- 2026-06-16: Implemented AC1-AC4 + tests (Romain G.). In-place ACME renewal,
+  bound-only auto-renewal, per-process rate-limit cooldown, startup orphan
+  purge. Status -> Review.
+- 2026-06-16: QA round (Romain G.). Actioned multi-agent review: union-set
+  orphan identity + single-pass selector, 7 day cooldown clamp, `in_cooldown`
+  extraction + per-tick sweep, extra tests. Version bump 1.5.11 -> 1.5.12 and
+  CHANGELOG. Clippy (exact CI command) clean, tests green.

--- a/lorica-api/Cargo.toml
+++ b/lorica-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-api"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -9,11 +9,11 @@ description = "REST API for Lorica reverse proxy management"
 
 [dependencies]
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-config = { version = "1.5.11", path = "../lorica-config" }
-lorica-dashboard = { version = "1.5.11", path = "../lorica-dashboard" }
+lorica-config = { version = "1.5.12", path = "../lorica-config" }
+lorica-dashboard = { version = "1.5.12", path = "../lorica-dashboard" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
-lorica-bench = { version = "1.5.11", path = "../lorica-bench" }
+lorica-bench = { version = "1.5.12", path = "../lorica-bench" }
 # Used in `certificates.rs::validate_certificate_bundle` to gate
 # every cert upload (POST /certificates, PUT /certificates/{id},
 # POST /config/import) with the exact loader the worker uses :

--- a/lorica-api/openapi.yaml
+++ b/lorica-api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lorica API
   description: REST API for Lorica reverse proxy management
-  version: "1.5.11"
+  version: "1.5.12"
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/lorica-api/src/acme/dns01.rs
+++ b/lorica-api/src/acme/dns01.rs
@@ -120,6 +120,7 @@ pub async fn provision_certificate_dns(
         challenger.as_ref(),
         &acme_method,
         dns_provider_id,
+        None,
     )
     .await;
 
@@ -157,6 +158,11 @@ pub(super) fn acme_dns_base_domain(domain: &str) -> &str {
 /// `acme_method` is stored on the certificate (e.g. "dns01-cloudflare").
 /// `encrypted_dns_config` is the encrypted JSON of the DNS credentials (legacy).
 /// `dns_provider_id` references a global DNS provider (new approach).
+///
+/// When `existing_cert_id` is `Some`, the freshly issued leaf is
+/// persisted in place on that row via `update_certificate` (same id,
+/// route bindings untouched); when `None`, a new row is inserted with
+/// a fresh UUID. The returned id is the id that now carries the leaf.
 pub(super) async fn provision_with_acme_dns(
     state: &AppState,
     config: &AcmeConfig,
@@ -164,6 +170,7 @@ pub(super) async fn provision_with_acme_dns(
     challenger: &dyn DnsChallenger,
     acme_method: &str,
     dns_provider_id: Option<String>,
+    existing_cert_id: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     use instant_acme::{
         Account, AuthorizationStatus, ChallengeType, Identifier, NewAccount, NewOrder, OrderStatus,
@@ -314,9 +321,13 @@ pub(super) async fn provision_with_acme_dns(
 
     let key_pem = private_key.serialize_pem();
 
-    // Store certificate in database
+    // Store certificate in database. On renewal (`existing_cert_id`
+    // is `Some`) update the row in place so the id and every route
+    // binding survive ; on first issuance insert a fresh row.
     let now = chrono::Utc::now();
-    let cert_id = uuid::Uuid::new_v4().to_string();
+    let is_renewal = existing_cert_id.is_some();
+    let cert_id = existing_cert_id
+        .map_or_else(|| uuid::Uuid::new_v4().to_string(), ToString::to_string);
     let fingerprint = format!("acme-dns:{}", domains.join(","));
 
     let cert = lorica_config::models::Certificate {
@@ -335,6 +346,8 @@ pub(super) async fn provision_with_acme_dns(
         not_after: now + chrono::Duration::days(90),
         is_acme: true,
         acme_auto_renew: true,
+        // `update_certificate` does not touch `created_at`, so the
+        // original insert timestamp is preserved on a renewal.
         created_at: now,
         acme_method: Some(acme_method.to_string()),
 
@@ -342,7 +355,11 @@ pub(super) async fn provision_with_acme_dns(
     };
 
     let (cert, export_snapshot) = db_blocking(&state.store, move |store| {
-        store.create_certificate(&cert)?;
+        if is_renewal {
+            store.update_certificate(&cert)?;
+        } else {
+            store.create_certificate(&cert)?;
+        }
         let snapshot = crate::cert_export::snapshot_export_inputs(store);
         Ok::<_, ApiError>((cert, snapshot))
     })

--- a/lorica-api/src/acme/http01.rs
+++ b/lorica-api/src/acme/http01.rs
@@ -72,7 +72,7 @@ pub async fn provision_certificate(
         "starting ACME certificate provisioning"
     );
 
-    let result = provision_with_acme(&state, &config, &domains).await;
+    let result = provision_with_acme(&state, &config, &domains, None).await;
 
     match result {
         Ok(cert_id) => {
@@ -115,10 +115,17 @@ pub async fn serve_challenge(
 
 /// Internal ACME provisioning logic using instant-acme.
 /// Supports multi-domain SAN certificates (one order, N challenges).
+///
+/// When `existing_cert_id` is `Some`, the freshly issued leaf is
+/// persisted in place on that row via `update_certificate` (same id,
+/// route bindings untouched); when `None`, a new row is inserted with
+/// a fresh UUID. The returned id is the id that now carries the leaf:
+/// the existing id on renewal, the fresh UUID on first issuance.
 pub(super) async fn provision_with_acme(
     state: &AppState,
     config: &AcmeConfig,
     domains: &[String],
+    existing_cert_id: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     use instant_acme::{
         Account, AuthorizationStatus, ChallengeType, Identifier, NewAccount, NewOrder, OrderStatus,
@@ -224,9 +231,13 @@ pub(super) async fn provision_with_acme(
 
     let key_pem = private_key.serialize_pem();
 
-    // Store certificate in database
+    // Store certificate in database. On renewal (`existing_cert_id`
+    // is `Some`) update the row in place so the id and every route
+    // binding survive ; on first issuance insert a fresh row.
     let now = chrono::Utc::now();
-    let cert_id = uuid::Uuid::new_v4().to_string();
+    let is_renewal = existing_cert_id.is_some();
+    let cert_id = existing_cert_id
+        .map_or_else(|| uuid::Uuid::new_v4().to_string(), ToString::to_string);
     let san_domains: Vec<String> = domains.to_vec();
     let fingerprint = format!("acme:{}", domains.join(","));
 
@@ -246,6 +257,8 @@ pub(super) async fn provision_with_acme(
         not_after: now + chrono::Duration::days(90),
         is_acme: true,
         acme_auto_renew: true,
+        // `update_certificate` does not touch `created_at`, so the
+        // original insert timestamp is preserved on a renewal.
         created_at: now,
         acme_method: Some("http01".into()),
 
@@ -253,7 +266,11 @@ pub(super) async fn provision_with_acme(
     };
 
     let (cert, export_snapshot) = db_blocking(&state.store, move |store| {
-        store.create_certificate(&cert)?;
+        if is_renewal {
+            store.update_certificate(&cert)?;
+        } else {
+            store.create_certificate(&cert)?;
+        }
         let snapshot = crate::cert_export::snapshot_export_inputs(store);
         Ok::<_, ApiError>((cert, snapshot))
     })

--- a/lorica-api/src/acme/mod.rs
+++ b/lorica-api/src/acme/mod.rs
@@ -59,6 +59,6 @@ pub use dns_challengers::{
 };
 pub use expiry::{check_cert_expiry, spawn_cert_expiry_check_task};
 pub use http01::{provision_certificate, serve_challenge, AcmeProvisionRequest};
-pub use renewal::{renew_certificate, spawn_renewal_task};
+pub use renewal::{renew_certificate, spawn_renewal_task, superseded_orphans};
 pub use store::AcmeChallengeStore;
 pub use types::{PendingDnsChallenge, PendingDnsChallenges};

--- a/lorica-api/src/acme/renewal.rs
+++ b/lorica-api/src/acme/renewal.rs
@@ -14,8 +14,11 @@
 
 //! Background renewal task and manual renewal endpoint.
 
+use std::collections::{HashMap, HashSet};
+
 use axum::extract::{Extension, Path};
 use axum::Json;
+use chrono::{DateTime, Utc};
 use tracing::{error, info, warn};
 
 use crate::db::db_blocking;
@@ -53,6 +56,117 @@ pub(super) fn should_auto_renew(
     days_remaining <= threshold_days
 }
 
+/// Pure predicate : is `cert_id` referenced by at least one route ?
+///
+/// The auto-renewal loop renews only route-bound certificates. An
+/// unbound ACME cert renewed in place would never be served and, in
+/// the old insert-then-reassign design, spawned an unbound duplicate
+/// on every cycle (the 2026-06-16 `mail.kaliaops.com` incident). The
+/// `bound_ids` set is built from `routes.certificate_id` exactly like
+/// the resolver's active-cert derivation in `reload_cert_resolver`.
+pub(super) fn is_bound(cert_id: &str, bound_ids: &HashSet<String>) -> bool {
+    bound_ids.contains(cert_id)
+}
+
+/// Pure classifier : when `msg` is a Let's Encrypt rate-limit error,
+/// return the cooldown instant before which the loop must not re-
+/// attempt this certificate ; otherwise return `None`.
+///
+/// A rate-limit error is detected by the ACME problem-type URN
+/// (`rateLimited`) or the human-readable "too many certificates"
+/// phrasing. When present, the `retry after <stamp>` timestamp
+/// (`%Y-%m-%d %H:%M:%S` UTC, e.g. `2026-06-11 06:19:40 UTC`) drives
+/// the cooldown ; if no stamp parses, a safe 24h default from `now`
+/// is used so the loop still backs off.
+pub(super) fn cooldown_from_error(msg: &str, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let is_rate_limited = msg.contains("rateLimited") || msg.contains("too many certificates");
+    if !is_rate_limited {
+        return None;
+    }
+
+    // A Let's Encrypt rate-limit window never legitimately exceeds the
+    // 168h (7 day) accounting period. Clamp the parsed deadline so a
+    // malformed or hostile `retry after` (a far-future stamp from a
+    // compromised or buggy ACME endpoint) cannot suspend auto-renewal
+    // long enough to let the live certificate silently expire.
+    let max_cooldown = now + chrono::Duration::days(7);
+    if let Some(after) = msg.split("retry after ").nth(1) {
+        // The stamp is followed by " UTC"; take everything up to it.
+        let stamp = after.split(" UTC").next().unwrap_or(after).trim();
+        if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(stamp, "%Y-%m-%d %H:%M:%S") {
+            let parsed = DateTime::from_naive_utc_and_offset(naive, Utc);
+            return Some(parsed.min(max_cooldown));
+        }
+    }
+
+    Some(now + chrono::Duration::hours(24))
+}
+
+/// Pure predicate : is `cert_id` within an active rate-limit cooldown
+/// at `now` ? Extracted so the auto-renewal loop's skip decision (AC3)
+/// is unit-testable without the network-bound renewal path.
+pub(super) fn in_cooldown(
+    cooldown: &HashMap<String, DateTime<Utc>>,
+    cert_id: &str,
+    now: DateTime<Utc>,
+) -> bool {
+    cooldown.get(cert_id).is_some_and(|until| *until > now)
+}
+
+/// Pure selector : among `certs`, return the ids of ACME certificates
+/// that are BOTH unreferenced by any route AND superseded by a sibling
+/// (same identifier set, strictly later `not_after`).
+///
+/// The identifier set is the UNION of the primary `domain` and the
+/// `san_domains`, sorted and de-duplicated. Keying on the union (not
+/// the `(domain, sans)` pair) means an uploaded twin that stores its
+/// SANs without repeating the primary still matches an ACME cert that
+/// lists the primary inside its SAN set: both cover the same names, so
+/// both share one identity, and ordering differences never defeat the
+/// match. A unique unbound cert with no newer sibling is kept (an
+/// operator may still bind it) ; the newest cert of a duplicate group
+/// is kept (nothing supersedes it), and ties on `not_after` keep both.
+///
+/// Used by the startup purge (AC4) to clear the orphan rows the old
+/// insert-then-reassign renewal accumulated before this fix.
+pub fn superseded_orphans(
+    certs: &[lorica_config::models::Certificate],
+    bound_ids: &HashSet<String>,
+) -> Vec<String> {
+    fn identity_key(cert: &lorica_config::models::Certificate) -> Vec<String> {
+        let mut names: Vec<String> = cert.san_domains.clone();
+        names.push(cert.domain.clone());
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    // One pass to record the latest `not_after` per identity, so the
+    // supersede test below is O(n) rather than O(n^2).
+    let mut latest: HashMap<Vec<String>, DateTime<Utc>> = HashMap::new();
+    for cert in certs {
+        latest
+            .entry(identity_key(cert))
+            .and_modify(|current| {
+                if cert.not_after > *current {
+                    *current = cert.not_after;
+                }
+            })
+            .or_insert(cert.not_after);
+    }
+
+    certs
+        .iter()
+        .filter(|cert| cert.is_acme && !bound_ids.contains(&cert.id))
+        .filter(|cert| {
+            latest
+                .get(&identity_key(cert))
+                .is_some_and(|newest| *newest > cert.not_after)
+        })
+        .map(|cert| cert.id.clone())
+        .collect()
+}
+
 use super::config::AcmeConfig;
 use super::dns01::provision_with_acme_dns;
 use super::dns_challengers::{build_dns_challenger, DnsChallengeConfig};
@@ -62,7 +176,13 @@ use super::http01::provision_with_acme;
 ///
 /// Runs every `check_interval` and renews certificates where:
 /// - `is_acme == true` and `acme_auto_renew == true`
+/// - The cert is referenced by at least one route (unbound certs are
+///   never auto-renewed, see [`is_bound`])
 /// - Days until expiry <= `renewal_threshold_days`
+///
+/// On a Let's Encrypt rate-limit error the cert is put on a per-process
+/// cooldown (see [`cooldown_from_error`]) so the loop stops hammering
+/// the ACME endpoint until the quota window reopens.
 pub fn spawn_renewal_task(
     state: AppState,
     check_interval: std::time::Duration,
@@ -71,6 +191,12 @@ pub fn spawn_renewal_task(
 ) -> tokio::task::JoinHandle<()> {
     let tracker = state.task_tracker.clone();
     tracker.spawn(async move {
+        // Per-process rate-limit cooldown, keyed by cert id. Declared
+        // outside the loop so it persists across `check_interval`
+        // ticks for the lifetime of the task. Not persisted across
+        // restarts (out of scope for this patch).
+        let mut rate_limit_cooldown: HashMap<String, DateTime<Utc>> = HashMap::new();
+
         loop {
             tokio::time::sleep(check_interval).await;
 
@@ -82,8 +208,35 @@ pub fn spawn_renewal_task(
                 }
             };
 
+            // Build the set of cert ids referenced by at least one
+            // route, using the same derivation as the resolver
+            // reload, so we never auto-renew an unbound cert.
+            let bound_ids: HashSet<String> =
+                match db_blocking(&state.store, |store| store.list_routes()).await {
+                    Ok(routes) => routes
+                        .iter()
+                        .filter_map(|r| r.certificate_id.clone())
+                        .collect(),
+                    Err(e) => {
+                        warn!(error = %e, "ACME renewal: failed to list routes");
+                        continue;
+                    }
+                };
+
             let now = chrono::Utc::now();
+            // Drop expired cooldown entries so the map stays bounded by
+            // the count of currently rate-limited certs (a cert that is
+            // decommissioned mid-cooldown is swept once its window ends).
+            rate_limit_cooldown.retain(|_, until| *until > now);
+
             for cert in &certs {
+                // Skip certs not bound to any route. An unbound cert
+                // is never served, so renewing it is pure quota waste
+                // and, before in-place renewal, spawned orphans.
+                if !is_bound(&cert.id, &bound_ids) {
+                    continue;
+                }
+
                 // Pre-filter via the pure `should_auto_renew` helper so
                 // the branching stays unit-testable. The helper already
                 // rules out non-ACME, opt-out, dns01-manual, and out-of-
@@ -97,6 +250,21 @@ pub fn spawn_renewal_task(
                 }
                 let days_remaining = (cert.not_after - now).num_days();
                 if days_remaining > renewal_threshold_days {
+                    continue;
+                }
+
+                // Honour an active rate-limit cooldown before doing any
+                // work for this cert (expired entries were swept above,
+                // so a present entry is still active).
+                if in_cooldown(&rate_limit_cooldown, &cert.id, now) {
+                    if let Some(until) = rate_limit_cooldown.get(&cert.id) {
+                        info!(
+                            domain = %cert.domain,
+                            cert_id = %cert.id,
+                            retry_after = %until,
+                            "skipping ACME renewal: rate-limit cooldown active"
+                        );
+                    }
                     continue;
                 }
 
@@ -148,43 +316,32 @@ pub fn spawn_renewal_task(
                         all_domains.push(d.clone());
                     }
                 }
-                match renew_with_method(&state, cert, &config, &all_domains).await {
-                    Ok(new_cert_id) => {
-                        // Reassign routes from old cert to new cert,
-                        // then delete the old certificate (single
-                        // store acquisition, same granularity as the
-                        // former lock scope).
-                        let old_id = cert.id.clone();
-                        let renewed_id = new_cert_id.clone();
-                        if let Err(e) = db_blocking(&state.store, move |store| {
-                            if let Ok(reassigned) =
-                                store.reassign_certificate(&old_id, &renewed_id)
-                            {
-                                if reassigned > 0 {
-                                    info!(old_id = %old_id, new_id = %renewed_id, routes = reassigned, "routes reassigned to renewed certificate");
-                                }
-                            }
-                            // Delete old certificate
-                            if let Err(e) = store.delete_certificate(&old_id) {
-                                warn!(old_id = %old_id, error = %e, "failed to delete old certificate after renewal");
-                            }
-                            Ok::<_, ApiError>(())
-                        })
-                        .await
-                        {
-                            warn!(old_id = %cert.id, error = %e, "store access failed after renewal");
-                        }
+                // In-place renewal : the leaf is written back onto the
+                // same row (`Some(cert.id)`), so the id and every route
+                // binding survive. No reassign, no delete, no orphan.
+                match renew_with_method(&state, cert, &config, &all_domains, Some(&cert.id)).await {
+                    Ok(_) => {
+                        rate_limit_cooldown.remove(&cert.id);
                         state.rotate_bot_hmac_on_cert_event().await;
                         state.notify_config_changed();
                         info!(
                             domain = %cert.domain,
-                            old_cert_id = %cert.id,
-                            new_cert_id = %new_cert_id,
+                            cert_id = %cert.id,
                             acme_method = ?cert.acme_method,
                             "ACME certificate renewed successfully"
                         );
                     }
                     Err(e) => {
+                        let msg = e.to_string();
+                        if let Some(until) = cooldown_from_error(&msg, now) {
+                            rate_limit_cooldown.insert(cert.id.clone(), until);
+                            info!(
+                                domain = %cert.domain,
+                                cert_id = %cert.id,
+                                retry_after = %until,
+                                "ACME renewal rate-limited; cooldown recorded"
+                            );
+                        }
                         error!(
                             domain = %cert.domain,
                             error = %e,
@@ -230,41 +387,27 @@ pub async fn renew_certificate(
         }
     }
 
-    let new_cert_id = renew_with_method(&state, &cert, &config, &all_domains)
+    // In-place renewal : same id, route bindings untouched (AC1).
+    renew_with_method(&state, &cert, &config, &all_domains, Some(&cert.id))
         .await
         .map_err(|e| ApiError::Internal(format!("ACME renewal failed: {e}")))?;
 
-    // Reassign routes and delete old cert
-    {
-        let old_id = cert.id.clone();
-        let renewed_id = new_cert_id.clone();
-        db_blocking(&state.store, move |store| {
-            if let Ok(reassigned) = store.reassign_certificate(&old_id, &renewed_id) {
-                if reassigned > 0 {
-                    tracing::info!(old_id = %old_id, new_id = %renewed_id, routes = reassigned, "routes reassigned to renewed certificate");
-                }
-            }
-            if let Err(e) = store.delete_certificate(&old_id) {
-                tracing::warn!(old_id = %old_id, error = %e, "failed to delete old certificate after renewal");
-            }
-            Ok::<_, ApiError>(())
-        })
-        .await?;
-    }
     state.rotate_bot_hmac_on_cert_event().await;
     state.notify_config_changed();
 
     tracing::info!(
         domain = %cert.domain,
-        old_cert_id = %cert.id,
-        new_cert_id = %new_cert_id,
+        cert_id = %cert.id,
         "certificate manually renewed"
     );
 
+    // In-place renewal keeps the id, so `old_cert_id == new_cert_id`.
+    // Both fields are retained for response-shape compatibility with
+    // existing API clients (the dashboard types this exact shape).
     Ok(crate::error::json_data(serde_json::json!({
         "renewed": true,
         "old_cert_id": cert.id,
-        "new_cert_id": new_cert_id,
+        "new_cert_id": cert.id,
         "domain": cert.domain,
     })))
 }
@@ -274,16 +417,21 @@ pub async fn renew_certificate(
 /// - `"http01"` or `None` -> HTTP-01 (original behavior)
 /// - `"dns01-cloudflare"` / `"dns01-route53"` / `"dns01-ovh"` -> decrypt config, build challenger
 /// - `"dns01-manual"` -> error (requires manual renewal)
+///
+/// `existing_cert_id` is threaded to the provisioning helpers so the
+/// renewed leaf updates that row in place (same id) rather than
+/// inserting a new certificate.
 async fn renew_with_method(
     state: &AppState,
     cert: &lorica_config::models::Certificate,
     config: &AcmeConfig,
     domains: &[String],
+    existing_cert_id: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let method = cert.acme_method.as_deref().unwrap_or("http01");
 
     match method {
-        "http01" => provision_with_acme(state, config, domains).await,
+        "http01" => provision_with_acme(state, config, domains, existing_cert_id).await,
         "dns01-manual" => Err("manual DNS-01 certificates require manual renewal - \
              use the provision-dns-manual endpoint"
             .into()),
@@ -339,6 +487,7 @@ async fn renew_with_method(
                 challenger.as_ref(),
                 m,
                 dns_provider_id,
+                existing_cert_id,
             )
             .await
         }

--- a/lorica-api/src/acme/tests.rs
+++ b/lorica-api/src/acme/tests.rs
@@ -753,6 +753,288 @@ fn should_auto_renew_accepts_already_expired() {
     assert!(should_auto_renew(&cert, now, 30));
 }
 
+// --- is_bound (AC2) ---
+//
+// The renewal loop renews only route-bound certs. The pure
+// predicate pins that an unbound cert is skipped regardless of its
+// expiry, which is the 2026-06-16 incident root cause.
+
+use std::collections::HashSet;
+
+use super::renewal::is_bound;
+
+#[test]
+fn is_bound_true_when_referenced_by_a_route() {
+    let bound: HashSet<String> = ["cert-a".to_string(), "cert-b".to_string()]
+        .into_iter()
+        .collect();
+    assert!(is_bound("cert-a", &bound));
+}
+
+#[test]
+fn is_bound_false_when_not_referenced() {
+    let bound: HashSet<String> = ["cert-a".to_string()].into_iter().collect();
+    assert!(
+        !is_bound("cert-orphan", &bound),
+        "an unbound cert must never be picked up by the renewal loop"
+    );
+}
+
+#[test]
+fn is_bound_false_for_empty_set() {
+    let bound: HashSet<String> = HashSet::new();
+    assert!(!is_bound("cert-a", &bound));
+}
+
+// --- cooldown_from_error (AC3) ---
+//
+// Classifies a Let's Encrypt rate-limit error and extracts the
+// retry-after instant so the loop stops re-attempting before the
+// quota window reopens. Non-rate-limit errors return None.
+
+use super::renewal::cooldown_from_error;
+
+#[test]
+fn cooldown_from_error_parses_real_rate_limit_message() {
+    let now = chrono::Utc::now();
+    let msg = "too many certificates (5) already issued for this exact set of identifiers \
+               in the last 168h0m0s, retry after 2026-06-11 06:19:40 UTC: see \
+               https://letsencrypt.org/docs/rate-limits/ \
+               (urn:ietf:params:acme:error:rateLimited)";
+    let cooldown = cooldown_from_error(msg, now).expect("rate-limit error must yield a cooldown");
+    let expected = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+        chrono::NaiveDateTime::parse_from_str("2026-06-11 06:19:40", "%Y-%m-%d %H:%M:%S")
+            .expect("test stamp parses"),
+        chrono::Utc,
+    );
+    assert_eq!(cooldown, expected);
+}
+
+#[test]
+fn cooldown_from_error_falls_back_to_24h_without_stamp() {
+    let now = chrono::Utc::now();
+    // Rate-limit URN present but no parseable retry-after stamp.
+    let msg = "rateLimited: too many certificates already issued";
+    let cooldown =
+        cooldown_from_error(msg, now).expect("rate-limit error must yield a cooldown");
+    assert_eq!(cooldown, now + chrono::Duration::hours(24));
+}
+
+#[test]
+fn cooldown_from_error_returns_none_for_non_rate_limit_error() {
+    let now = chrono::Utc::now();
+    let msg = "certificate poll failed: connection reset by peer";
+    assert!(
+        cooldown_from_error(msg, now).is_none(),
+        "a non-rate-limit error must not record a cooldown"
+    );
+}
+
+#[test]
+fn cooldown_from_error_clamps_far_future_stamp_to_seven_days() {
+    let now = chrono::Utc::now();
+    // A hostile or buggy ACME endpoint returns a retry-after years out;
+    // the cooldown must be clamped to the 7 day quota window so it
+    // cannot suspend auto-renewal long enough to let the cert expire.
+    let msg = "too many certificates, retry after 2099-01-01 00:00:00 UTC: \
+               (urn:ietf:params:acme:error:rateLimited)";
+    let cooldown = cooldown_from_error(msg, now).expect("rate-limit error must yield a cooldown");
+    assert_eq!(cooldown, now + chrono::Duration::days(7));
+}
+
+#[test]
+fn cooldown_from_error_falls_back_when_stamp_is_garbage() {
+    let now = chrono::Utc::now();
+    // `retry after` is present but the stamp does not parse; the safe
+    // 24h default applies rather than silently dropping the cooldown.
+    let msg = "rateLimited: too many certificates, retry after soon: see docs";
+    let cooldown = cooldown_from_error(msg, now).expect("rate-limit error must yield a cooldown");
+    assert_eq!(cooldown, now + chrono::Duration::hours(24));
+}
+
+// --- in_cooldown (AC3) ---
+//
+// The loop skips a cert whose cooldown is still in the future. The
+// pure predicate pins future -> skip, past -> attempt, absent ->
+// attempt, the integrated rate-limit-respect behavior the loop relies
+// on (the loop sweeps expired entries before calling this).
+
+use std::collections::HashMap;
+
+use super::renewal::in_cooldown;
+
+#[test]
+fn in_cooldown_true_for_future_entry() {
+    let now = chrono::Utc::now();
+    let mut map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    map.insert("cert-a".into(), now + chrono::Duration::hours(1));
+    assert!(in_cooldown(&map, "cert-a", now));
+}
+
+#[test]
+fn in_cooldown_false_for_expired_entry() {
+    let now = chrono::Utc::now();
+    let mut map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    map.insert("cert-a".into(), now - chrono::Duration::hours(1));
+    assert!(
+        !in_cooldown(&map, "cert-a", now),
+        "an expired cooldown must not suppress a renewal attempt"
+    );
+}
+
+#[test]
+fn in_cooldown_false_when_absent() {
+    let now = chrono::Utc::now();
+    let map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    assert!(!in_cooldown(&map, "cert-a", now));
+}
+
+// --- superseded_orphans (AC4) ---
+//
+// Selects ACME certs that are both unbound and superseded by a
+// newer sibling for the same identifier set. Unique unbound certs
+// and the newest of a duplicate group are kept.
+
+use super::superseded_orphans;
+
+fn orphan_cert_fixture(
+    id: &str,
+    domain: &str,
+    sans: &[&str],
+    not_after_days: i64,
+) -> lorica_config::models::Certificate {
+    let now = chrono::Utc::now();
+    lorica_config::models::Certificate {
+        id: id.into(),
+        domain: domain.into(),
+        san_domains: sans.iter().map(|s| (*s).to_string()).collect(),
+        fingerprint: "fp".into(),
+        cert_pem: "---CERT---".into(),
+        key_pem: "---KEY---".into(),
+        issuer: "Let's Encrypt".into(),
+        not_before: now - chrono::Duration::days(1),
+        not_after: now + chrono::Duration::days(not_after_days),
+        is_acme: true,
+        acme_auto_renew: true,
+        created_at: now - chrono::Duration::days(1),
+        acme_method: Some("http01".into()),
+        acme_dns_provider_id: None,
+    }
+}
+
+#[test]
+fn superseded_orphans_purges_older_unbound_duplicate() {
+    // Two unbound certs for the same identity ; only the strictly
+    // older one is superseded and must be purged.
+    let old = orphan_cert_fixture("cert-old", "mail.example.com", &["mail.example.com"], 10);
+    let new = orphan_cert_fixture("cert-new", "mail.example.com", &["mail.example.com"], 80);
+    let bound: HashSet<String> = HashSet::new();
+
+    let purge = superseded_orphans(&[old, new], &bound);
+    assert_eq!(purge, vec!["cert-old".to_string()]);
+}
+
+#[test]
+fn superseded_orphans_keeps_bound_cert_even_if_superseded() {
+    // The older cert is bound to a route, so it must be kept even
+    // though a newer sibling exists.
+    let old = orphan_cert_fixture("cert-old", "mail.example.com", &["mail.example.com"], 10);
+    let new = orphan_cert_fixture("cert-new", "mail.example.com", &["mail.example.com"], 80);
+    let bound: HashSet<String> = ["cert-old".to_string()].into_iter().collect();
+
+    let purge = superseded_orphans(&[old, new], &bound);
+    assert!(
+        purge.is_empty(),
+        "a route-bound cert must never be purged, even when superseded"
+    );
+}
+
+#[test]
+fn superseded_orphans_keeps_unique_unbound_cert() {
+    // A lone unbound cert has no newer sibling, so an operator may
+    // still bind it ; it must be kept.
+    let lone = orphan_cert_fixture("cert-lone", "solo.example.com", &["solo.example.com"], 10);
+    let bound: HashSet<String> = HashSet::new();
+
+    let purge = superseded_orphans(&[lone], &bound);
+    assert!(purge.is_empty());
+}
+
+#[test]
+fn superseded_orphans_keeps_newest_of_duplicate_group() {
+    // Nothing supersedes the newest cert, so it is not an orphan.
+    let old = orphan_cert_fixture("cert-old", "mail.example.com", &["mail.example.com"], 10);
+    let new = orphan_cert_fixture("cert-new", "mail.example.com", &["mail.example.com"], 80);
+    let bound: HashSet<String> = HashSet::new();
+
+    let purge = superseded_orphans(&[old, new], &bound);
+    assert!(!purge.contains(&"cert-new".to_string()));
+}
+
+#[test]
+fn superseded_orphans_matches_identity_ignoring_san_order() {
+    // Same identifier set in a different SAN order must still match,
+    // so the older dup is purged.
+    let old = orphan_cert_fixture(
+        "cert-old",
+        "example.com",
+        &["www.example.com", "example.com"],
+        10,
+    );
+    let new = orphan_cert_fixture(
+        "cert-new",
+        "example.com",
+        &["example.com", "www.example.com"],
+        80,
+    );
+    let bound: HashSet<String> = HashSet::new();
+
+    let purge = superseded_orphans(&[old, new], &bound);
+    assert_eq!(purge, vec!["cert-old".to_string()]);
+}
+
+#[test]
+fn superseded_orphans_matches_when_primary_absent_from_san_list() {
+    // An ACME cert lists the primary inside its SAN set; an uploaded
+    // twin omits the primary from its SANs. Both cover the same names,
+    // so the union-based identity must match and the older one purge.
+    let acme = orphan_cert_fixture(
+        "cert-acme",
+        "mail.example.com",
+        &["mail.example.com", "autodiscover.example.com"],
+        10,
+    );
+    let uploaded = orphan_cert_fixture(
+        "cert-uploaded",
+        "mail.example.com",
+        &["autodiscover.example.com"],
+        80,
+    );
+    let bound: HashSet<String> = HashSet::new();
+
+    let purge = superseded_orphans(&[acme, uploaded], &bound);
+    assert_eq!(purge, vec!["cert-acme".to_string()]);
+}
+
+#[test]
+fn superseded_orphans_keeps_both_on_not_after_tie() {
+    // Two unbound certs for the same identity with the EXACT same
+    // not_after supersede neither (strict comparison), so both stay.
+    let mut a = orphan_cert_fixture("cert-a", "mail.example.com", &["mail.example.com"], 30);
+    let mut b = orphan_cert_fixture("cert-b", "mail.example.com", &["mail.example.com"], 30);
+    // The fixtures capture `now` independently, so force an exact tie.
+    let shared = chrono::Utc::now() + chrono::Duration::days(30);
+    a.not_after = shared;
+    b.not_after = shared;
+    let bound: HashSet<String> = HashSet::new();
+
+    let purge = superseded_orphans(&[a, b], &bound);
+    assert!(
+        purge.is_empty(),
+        "certs tied on not_after supersede neither, so both are kept"
+    );
+}
+
 // --- DNS challenger HTTP coverage via wiremock ---
 //
 // These tests replace the provider's API with a local mock server,

--- a/lorica-bench/Cargo.toml
+++ b/lorica-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-bench"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -8,7 +8,7 @@ repository = "https://github.com/Rwx-G/Lorica"
 description = "SLA monitoring and load testing for Lorica reverse proxy"
 
 [dependencies]
-lorica-config = { version = "1.5.11", path = "../lorica-config" }
+lorica-config = { version = "1.5.12", path = "../lorica-config" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/lorica-challenge/Cargo.toml
+++ b/lorica-challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-challenge"
-version = "1.5.11"
+version = "1.5.12"
 edition = "2021"
 license = "Apache-2.0"
 description = "Bot-protection challenges (cookie + PoW + captcha) for Lorica"

--- a/lorica-command/Cargo.toml
+++ b/lorica-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-command"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/Cargo.toml
+++ b/lorica-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-config"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/src/tests.rs
+++ b/lorica-config/src/tests.rs
@@ -446,6 +446,79 @@ mod tests {
             .is_none());
     }
 
+    // ---- In-place ACME renewal (fix 1.5.12) ----
+
+    #[test]
+    fn test_acme_renewal_in_place_keeps_id_and_route_binding() {
+        // Models the renewal-store mutation: an ACME cert bound to a
+        // route is renewed in place via `update_certificate` (same id,
+        // new leaf + validity). The id must survive, the route must
+        // still reference it, the cert count must not grow, and
+        // `created_at` must be preserved.
+        let store = ConfigStore::open_in_memory().expect("test setup: in-memory store opens");
+
+        let mut cert = make_certificate();
+        cert.is_acme = true;
+        cert.acme_auto_renew = true;
+        cert.acme_method = Some("http01".into());
+        let original_id = cert.id.clone();
+        let original_created_at = cert.created_at;
+        store
+            .create_certificate(&cert)
+            .expect("test setup: certificate inserts");
+
+        let mut route = make_route();
+        route.certificate_id = Some(original_id.clone());
+        store
+            .create_route(&route)
+            .expect("test setup: route inserts");
+
+        // Renew in place: same id, fresh leaf and a later not_after.
+        let renewed = Certificate {
+            cert_pem: "-----BEGIN CERTIFICATE-----\nrenewed\n-----END CERTIFICATE-----".into(),
+            key_pem: "-----BEGIN PRIVATE KEY-----\nrenewed\n-----END PRIVATE KEY-----".into(),
+            not_after: cert.not_after + chrono::Duration::days(90),
+            // A renewal call would carry a fresh `created_at`, but
+            // `update_certificate` does not write that column.
+            created_at: Utc::now() + chrono::Duration::days(1),
+            ..cert.clone()
+        };
+        store
+            .update_certificate(&renewed)
+            .expect("test setup: certificate updates in place");
+
+        // Cert count did not grow (no orphan row).
+        let certs = store
+            .list_certificates()
+            .expect("test setup: certificates listed");
+        assert_eq!(certs.len(), 1, "in-place renewal must not insert a new row");
+
+        let fetched = store
+            .get_certificate(&original_id)
+            .expect("test setup: certificate fetch")
+            .expect("test setup: value present");
+        assert_eq!(fetched.id, original_id, "renewal must keep the same id");
+        assert!(
+            fetched.cert_pem.contains("renewed"),
+            "renewal must persist the new leaf"
+        );
+        assert_eq!(
+            fetched.created_at, original_created_at,
+            "update_certificate must preserve created_at"
+        );
+
+        // The route still points at the same cert id.
+        let fetched_route = store
+            .get_route(&route.id)
+            .expect("test setup: route fetch")
+            .expect("test setup: value present");
+        assert_eq!(
+            fetched_route.certificate_id,
+            Some(original_id),
+            "route binding must survive an in-place renewal"
+        );
+    }
+
     // ---- NotificationConfig CRUD ----
 
     #[test]

--- a/lorica-dashboard/Cargo.toml
+++ b/lorica-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-dashboard"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/frontend/package-lock.json
+++ b/lorica-dashboard/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.5.11",
+      "version": "1.5.12",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/lorica-dashboard/frontend/package.json
+++ b/lorica-dashboard/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.5.11",
+  "version": "1.5.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/lorica-geoip/Cargo.toml
+++ b/lorica-geoip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-geoip"
-version = "1.5.11"
+version = "1.5.12"
 edition = "2021"
 license = "Apache-2.0"
 description = "GeoIP country-code lookup for Lorica, wrapping maxminddb"

--- a/lorica-shmem/Cargo.toml
+++ b/lorica-shmem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-shmem"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-worker/Cargo.toml
+++ b/lorica-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-worker"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica/Cargo.toml
+++ b/lorica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica"
-version = "1.5.11"
+version = "1.5.12"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -39,21 +39,21 @@ lorica-lb = { version = "0.1.0", path = "../lorica-lb", optional = true, default
 # call site explicit.
 lorica-ketama = { version = "0.1.0", path = "../lorica-ketama" }
 lorica-proxy = { version = "0.1.0", path = "../lorica-proxy", optional = true, default-features = false }
-lorica-config = { version = "1.5.11", path = "../lorica-config" }
-lorica-api = { version = "1.5.11", path = "../lorica-api" }
+lorica-config = { version = "1.5.12", path = "../lorica-config" }
+lorica-api = { version = "1.5.12", path = "../lorica-api" }
 lorica-error = { version = "0.1.0", path = "../lorica-error" }
 lorica-tls = { version = "0.1.0", path = "../lorica-tls" }
-lorica-worker = { version = "1.5.11", path = "../lorica-worker" }
-lorica-command = { version = "1.5.11", path = "../lorica-command" }
-lorica-shmem = { version = "1.5.11", path = "../lorica-shmem" }
+lorica-worker = { version = "1.5.12", path = "../lorica-worker" }
+lorica-command = { version = "1.5.12", path = "../lorica-command" }
+lorica-shmem = { version = "1.5.12", path = "../lorica-shmem" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 lorica-limits = { version = "0.1.0", path = "../lorica-limits" }
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-geoip = { version = "1.5.11", path = "../lorica-geoip" }
-lorica-challenge = { version = "1.5.11", path = "../lorica-challenge" }
+lorica-geoip = { version = "1.5.12", path = "../lorica-geoip" }
+lorica-challenge = { version = "1.5.12", path = "../lorica-challenge" }
 once_cell = { workspace = true }
-lorica-bench = { version = "1.5.11", path = "../lorica-bench" }
+lorica-bench = { version = "1.5.12", path = "../lorica-bench" }
 regex = "1"
 # HTML sanitization for operator-supplied error_page_html (v1.5.0
 # audit finding HIGH-1). Whitelist-based parser replaces the

--- a/lorica/src/startup/mod.rs
+++ b/lorica/src/startup/mod.rs
@@ -168,6 +168,11 @@ pub(crate) async fn run_api_server(
         .with_task_tracker(state.task_tracker.clone());
     let rate_limiter = RateLimiter::new();
 
+    // One-shot startup purge of superseded orphan ACME certs (fix
+    // 1.5.12). Shared by both modes here so single-process and
+    // supervisor cannot drift, exactly like the renewal spawn below.
+    purge_superseded_acme_orphans(&state.store).await;
+
     let _acme_renewal = lorica_api::acme::spawn_renewal_task(
         state.clone(),
         std::time::Duration::from_secs(12 * 3600),
@@ -185,6 +190,55 @@ pub(crate) async fn run_api_server(
     {
         error!(error = %e, "API server exited with error");
     }
+}
+
+/// Purge superseded orphan ACME certificates left over by the old
+/// insert-then-reassign renewal (fix 1.5.12). An orphan is an ACME
+/// cert that is unreferenced by any route AND has a sibling for the
+/// same identifier set with a later `not_after`. Unique unbound certs
+/// are kept (an operator may bind them); the decision lives in the
+/// pure `superseded_orphans` selector so it is unit-tested in
+/// `lorica-api`.
+///
+/// Best-effort and non-fatal: a store error is logged and startup
+/// continues, since a failed purge never blocks serving traffic.
+async fn purge_superseded_acme_orphans(store: &Arc<Mutex<ConfigStore>>) {
+    let s = store.lock().await;
+
+    let certs = match s.list_certificates() {
+        Ok(certs) => certs,
+        Err(e) => {
+            warn!(error = %e, "startup orphan purge: failed to list certificates");
+            return;
+        }
+    };
+    let bound_ids: std::collections::HashSet<String> = match s.list_routes() {
+        Ok(routes) => routes
+            .iter()
+            .filter_map(|r| r.certificate_id.clone())
+            .collect(),
+        Err(e) => {
+            warn!(error = %e, "startup orphan purge: failed to list routes");
+            return;
+        }
+    };
+
+    let orphan_ids = lorica_api::acme::superseded_orphans(&certs, &bound_ids);
+    if orphan_ids.is_empty() {
+        return;
+    }
+
+    for id in &orphan_ids {
+        if let Err(e) = s.delete_certificate(id) {
+            warn!(cert_id = %id, error = %e, "startup orphan purge: failed to delete orphan certificate");
+        }
+    }
+
+    info!(
+        count = orphan_ids.len(),
+        ids = ?orphan_ids,
+        "purged superseded orphan ACME certificates at startup"
+    );
 }
 
 /// Spawn the hourly retention loop shared by supervisor and


### PR DESCRIPTION
## Summary

Fixes ACME auto-renewal so a renewed certificate keeps its route binding, resolving the production incident where mail.kaliaops.com was re-requested daily until Let's Encrypt rate-limited the account.

## Root cause

Auto-renewal issued a new certificate (new id), reassigned routes old to new, then deleted the old one. When the reassignment matched no route (an unbound duplicate certificate for the same identifier set was renewed), the route stayed on the old certificate, which remained in the renewal window and was re-requested every cycle, exhausting the Let's Encrypt "certificates per exact set of identifiers per 168h" limit. The renewal machinery itself was healthy (route reassignment works for every other domain); the issue was renewing certificates that were not the route-bound one.

## Changes

- Renew in place: update the existing certificate row (same id) instead of insert + reassign + delete, so route bindings always survive. This matches how Caddy, Traefik and certbot replace a certificate.
- Skip auto-renewing certificates not bound to any route (no quota waste on orphans).
- Respect Let's Encrypt rate limiting: on a rateLimited error, back off until the returned retry-after (clamped to 7 days) instead of retrying every cycle.
- Startup purge of superseded orphan ACME certificates (unbound and replaced by a newer certificate for the same identifier set). Bound and unique certificates are never purged.

## Testing

- cargo clippy on the product crates with -D warnings: clean (matches CI).
- lorica-api 475 tests + lorica-config 181 tests, 0 failed. 7 new unit tests covering the rate-limit cooldown (parse, clamp, fallback), the bound-only skip, and orphan selection (tie and primary-absent-from-SAN identity).
- No new dependencies.

## Review

Implemented from docs/stories/fix-1.5.12-acme-renewal-in-place.md, then reviewed by a 3-agent BMAD pass and a 6-agent audit. Actioned findings: union-set orphan identity (so uploaded twins that omit the primary from their SANs still match), 7-day cooldown clamp, bounded cooldown map, and the extra tests above.
