### PR TITLE
fix(security): cert-export chown no longer crashes the proxy via seccomp SIGSYS (v1.5.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,42 @@ jobs:
           test -f /lib/systemd/system/lorica.service
           lorica --version
           echo ".deb installation verified OK"
+      - name: systemd unit - hardening lint
+        run: |
+          # The ~@chown:EPERM softening (v1.5.13) must stay in the shipped
+          # unit: without it, a cert-export configured with an owner
+          # UID/GID sends chown -> SECCOMP_RET_KILL and the proxy dies with
+          # SIGSYS. Deterministic gate so an accidental removal fails CI.
+          grep -q '^SystemCallFilter=~@chown:EPERM' /lib/systemd/system/lorica.service \
+            || { echo "FAIL: ~@chown:EPERM softening missing from the shipped unit"; exit 1; }
+          # Informational: unit load check + exposure score (see lorica-systemd.md).
+          sudo systemd-analyze verify /lib/systemd/system/lorica.service || true
+          sudo systemd-analyze security lorica.service --no-pager || true
+      - name: Regression - cert-export chown must fail soft, not SIGSYS
+        run: |
+          # Reproduce the v1.5.13 incident at the syscall level. Run chown
+          # under the EXACT SystemCallFilter directives shipped in the unit
+          # and assert the process is not killed by a signal. Before the
+          # fix, chown hit SECCOMP_RET_KILL and the probe would exit
+          # 128+31=159 (SIGSYS); with the fix chown returns EPERM and
+          # /bin/chown exits 1.
+          touch /tmp/seccomp-probe
+          args=()
+          while IFS= read -r line; do
+            args+=(-p "$line")
+          done < <(grep -E '^SystemCallFilter=' /lib/systemd/system/lorica.service)
+          echo "Applying ${#args[@]} filter directives from the shipped unit"
+          set +e
+          sudo systemd-run --quiet --pipe --wait --collect "${args[@]}" \
+            /bin/chown 1000:1000 /tmp/seccomp-probe
+          rc=$?
+          set -e
+          echo "chown-under-shipped-seccomp exit code: $rc"
+          if [ "$rc" -ge 128 ]; then
+            echo "FAIL: chown was killed by a signal under the shipped filter (SIGSYS regression)"
+            exit 1
+          fi
+          echo "OK: chown fails soft under the shipped filter (no SIGSYS)"
 
   test-rpm-install:
     name: Test .rpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,34 @@ jobs:
         with:
           node-version: 22
 
+      - name: Regression - cert-export chown must fail soft, not SIGSYS
+        run: |
+          # PR-time guard for the v1.5.13 crash: the source unit's
+          # SystemCallFilter must let chown fail soft (EPERM) instead of
+          # killing the process with SIGSYS. Lives here because
+          # build-and-package / test-deb-install are gated to main + tags
+          # and skip on pull requests, so the installed-unit probe never
+          # runs on a PR. Reads the directives straight from the repo unit.
+          grep -q '^SystemCallFilter=~@chown:EPERM' dist/lorica.service \
+            || { echo "FAIL: ~@chown:EPERM softening missing from dist/lorica.service"; exit 1; }
+          touch /tmp/seccomp-probe
+          args=()
+          while IFS= read -r line; do
+            args+=(-p "$line")
+          done < <(grep -E '^SystemCallFilter=' dist/lorica.service)
+          echo "Applying ${#args[@]} filter directives from dist/lorica.service"
+          set +e
+          sudo systemd-run --quiet --pipe --wait --collect "${args[@]}" \
+            /bin/chown 1000:1000 /tmp/seccomp-probe
+          rc=$?
+          set -e
+          echo "chown-under-shipped-seccomp exit code: $rc"
+          if [ "$rc" -ge 128 ]; then
+            echo "FAIL: chown killed by a signal under the shipped filter (SIGSYS regression)"
+            exit 1
+          fi
+          echo "OK: chown fails soft under the shipped filter (no SIGSYS)"
+
       - name: Build frontend
         run: |
           cd lorica-dashboard/frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Author: Rwx-G
 
 ## [Unreleased]
 
+## [1.5.13] - 2026-07-08
+
+### Fixed
+
+- Certificate export no longer crashes the entire proxy when an owner UID or group GID is configured. The shipped systemd unit's `SystemCallFilter=~@privileged` deny list includes the `chown` syscall family, so any export that tried to apply ownership (initial issuance, auto-renewal, or the "re-export all" operator action) issued a `chown` that seccomp answered with `SECCOMP_RET_KILL`, taking the supervisor process down with SIGSYS. All workers then lost the command channel and systemd restarted the service. As a result, renewed certificates configured with an export owner were never written to disk. The unit now downgrades only the `chown` family to fail-soft with `EPERM`, so the exporter falls back to `ExportOutcome::PermissionsSkipped` (the bundle is written with the configured file mode and left owned by the `lorica` user) instead of aborting. Renewed and re-exported certificates now land on disk as intended.
+
+### Security
+
+- The seccomp softening is scoped to the `chown` family alone, via a trailing `SystemCallFilter=~@chown:EPERM` that overrides only those syscalls. Every other `@privileged` and `@resources` syscall still hard-kills the process, and no capability (`CAP_CHOWN` included) is granted, so the sandbox exposure is unchanged for all non-`chown` syscalls. Exported private keys keep their `0640` file mode and `0750` directory mode, readable only by the `lorica` user and root.
+
 ## [1.5.12] - 2026-06-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,14 +97,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
  "cssparser",
  "html5ever",
  "maplit",
- "tendril",
  "url",
 ]
 
@@ -1300,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1359,25 +1358,13 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
  "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1782,16 +1769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,13 +2147,12 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -3462,12 +3438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,24 +3445,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3969,19 +3928,19 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -3989,32 +3948,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4326,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5294,22 +5240,21 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -5455,13 +5400,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -6310,9 +6253,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,7 +2907,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lorica"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "ammonia",
  "arc-swap",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-api"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-bench"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "chrono",
  "lorica-config",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-challenge"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-command"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "nix",
  "prost 0.13.5",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-config"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-dashboard"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "axum",
  "hyper 1.10.1",
@@ -3201,7 +3201,7 @@ version = "0.1.0"
 
 [[package]]
 name = "lorica-geoip"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-shmem"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "nix",
  "rand 0.9.4",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "lorica-worker"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "nix",
  "socket2 0.5.10",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/version-1.5.12-brightgreen.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.5.13-brightgreen.svg" alt="Version">
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Platform-Linux-0078D6.svg" alt="Platform">
   <img src="https://img.shields.io/badge/Lorica%20Tests-1306%2B-brightgreen.svg" alt="Lorica Tests">

--- a/dist/lorica.service
+++ b/dist/lorica.service
@@ -103,6 +103,21 @@ KeyringMode=private
 #                 LimitNOFILE via prlimit BEFORE exec, the
 #                 service itself never needs to call it.
 SystemCallFilter=~@privileged @resources
+# The `chown` family (chown/fchown/lchown/fchownat) is part of
+# @privileged and is therefore killed by the deny list above. The
+# v1.4.1 cert-export feature calls `chown` when an owner UID/GID is
+# configured (settings `cert_export_owner_uid` / `cert_export_group_gid`),
+# so a matching export would send SECCOMP_RET_KILL and take the whole
+# proxy down with SIGSYS - a hard crash for an optional feature. This
+# trailing rule overrides ONLY the chown family to fail soft with EPERM;
+# every other @privileged / @resources syscall still hard-kills. On EPERM
+# the exporter falls back to ExportOutcome::PermissionsSkipped
+# (lorica-api/src/cert_export.rs), writing the bundle with the configured
+# file mode (0640) and owner `lorica`, ownership change skipped. Operators
+# who need the `chown` to actually take effect must instead add CAP_CHOWN
+# and re-allow @chown (see CapabilityBoundingSet note above).
+# (v1.5.13 - fixes the mail.* cert-export re-export SIGSYS incident.)
+SystemCallFilter=~@chown:EPERM
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/rpm/lorica.spec
+++ b/dist/rpm/lorica.spec
@@ -1,5 +1,5 @@
 Name:           lorica
-Version:        1.5.12
+Version:        1.5.13
 Release:        1%{?dist}
 Summary:        Modern reverse proxy with built-in dashboard
 License:        Apache-2.0

--- a/docs/stories/fix-1.5.13-cert-export-seccomp.md
+++ b/docs/stories/fix-1.5.13-cert-export-seccomp.md
@@ -1,0 +1,115 @@
+# Fix 1.5.13 - cert-export `chown` crashed the proxy via seccomp SIGSYS
+
+Status: Review
+
+## Symptom
+
+An operator triggered the cert-export "re-export all" action (`POST
+/api/v1/cert-export/reapply`). Lorica returned HTTP 500 and the whole
+service went down, then systemd restarted it ~90 s later. The same class
+of failure prevented renewed certificates from being written to the
+configured export directory.
+
+## Root cause
+
+The shipped systemd unit hardens syscalls with:
+
+```
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+```
+
+The deny list uses the default action `SECCOMP_RET_KILL`, which kills the
+whole process with `SIGSYS` (signal 31). The `chown` family
+(`chown`/`fchown`/`lchown`/`fchownat`) is part of `@privileged`.
+
+The cert-export feature applies the configured owner UID/GID by calling
+`nix::unistd::chown` (`lorica-api/src/cert_export.rs:151`). Because the
+export runs in the privileged supervisor process (it serves the
+management API), that `chown` syscall was answered by the kernel with
+`SIGSYS`, killing the supervisor. All workers then lost their command
+channel (`command channel recv error: early eof`) and systemd tore the
+cgroup down after `TimeoutStopSec`.
+
+Journal evidence:
+
+```
+lorica.service: Main process exited, code=killed, status=31/SYS
+```
+
+The code was written to degrade gracefully when `CAP_CHOWN` is absent
+(`Err(Errno::EPERM) => Ok(false)` at `cert_export.rs:153`), but that
+contract assumes the syscall is *allowed* by seccomp and only denied by
+capabilities. seccomp evaluates before the capability check, so the kill
+happened before `EPERM` could ever be returned.
+
+## Fix
+
+Downgrade only the `chown` family from kill to a soft `EPERM`, without
+granting any capability, via a trailing directive in `dist/lorica.service`:
+
+```
+SystemCallFilter=~@chown:EPERM
+```
+
+`@chown` is a subset of `@privileged`; the later rule overrides only
+those syscalls, so every other `@privileged`/`@resources` syscall still
+hard-kills. On `EPERM` the exporter falls back to
+`ExportOutcome::PermissionsSkipped`: the bundle is written with the
+configured file mode (`0640`) and left owned by the `lorica` user.
+Operators who genuinely need the `chown` to take effect must instead add
+`CAP_CHOWN` to the bounding/ambient sets and re-allow `@chown`.
+
+## Syscall audit (proactive - are there other latent SIGSYS?)
+
+Every `@privileged`/`@resources` syscall reachable on the runtime path
+was traced. Result: `chown` is the only one, and it is now handled.
+
+- Privilege drop is entirely systemd's job (`User=`/`Group=` pre-exec);
+  the fork+exec path in `lorica-worker/src/manager.rs` never calls
+  `setuid`/`setgid`/`setgroups`.
+- No `setrlimit`/`prlimit`/`sched_setaffinity`/`setpriority`/`mbind`
+  call sites anywhere in the workspace (jemalloc is a dev-dependency
+  only).
+- `lorica-shmem` uses `memfd_create` + `mmap` (both in
+  `@system-service`), not `mount`/NUMA calls.
+
+Latent future risk (no action today): `lorica-core/src/server/daemon.rs`
+documents a would-be inline `setuid`/`setgid` daemonization path. It is a
+no-op since v1.3.0. If anyone ever reactivates it to run Lorica outside
+systemd, those calls would hit `@privileged` -> SIGSYS under the current
+unit.
+
+## Regression protection
+
+- CI job `test-deb-install` (ubuntu-latest, real systemd) now runs
+  `systemd-analyze verify` on the installed unit and a syscall-level
+  probe: `chown` executed under the unit's exact `SystemCallFilter`
+  directives must fail soft (EPERM, exit < 128), not be killed by a
+  signal. Before the fix this probe returns 159 (128 + SIGSYS).
+- The existing `cert_export.rs` unit tests already exercise the
+  `EPERM -> PermissionsSkipped` code contract (the test harness has no
+  `CAP_CHOWN`, so `chown` returns `EPERM` naturally). No Rust test can
+  catch the SIGSYS itself because `cargo test` does not apply the systemd
+  seccomp filter - hence the deb-install probe.
+
+## Verification not runnable on the Windows dev host
+
+`systemd-analyze` and the seccomp behaviour require Linux + systemd and a
+built package. They are validated by the CI run on the PR, or on the
+server after deploying the new `.deb`/`.rpm`. The Docker test suite was
+not run locally (Docker Desktop was not available on the dev host at fix
+time).
+
+## File List
+
+- `dist/lorica.service` - added `SystemCallFilter=~@chown:EPERM` + rationale comment
+- `.github/workflows/ci.yml` - `test-deb-install`: unit verify + seccomp chown regression probe
+- `CHANGELOG.md` - `[1.5.13]` Fixed + Security entries
+- version bump `1.5.12 -> 1.5.13` across the pinned files (see `docs/BUMP-CHECKLIST.md`)
+
+## Change Log
+
+- 2026-07-08 - Root-caused the SIGSYS crash to `@chown` in the seccomp deny
+  list, softened it to EPERM, audited for sibling syscalls (none found),
+  added the deb-install seccomp regression probe. Bump 1.5.12 -> 1.5.13.

--- a/docs/stories/fix-1.5.13-cert-export-seccomp.md
+++ b/docs/stories/fix-1.5.13-cert-export-seccomp.md
@@ -82,11 +82,14 @@ unit.
 
 ## Regression protection
 
-- CI job `test-deb-install` (ubuntu-latest, real systemd) now runs
-  `systemd-analyze verify` on the installed unit and a syscall-level
-  probe: `chown` executed under the unit's exact `SystemCallFilter`
-  directives must fail soft (EPERM, exit < 128), not be killed by a
-  signal. Before the fix this probe returns 159 (128 + SIGSYS).
+- CI job `test` (ubuntu-latest, real systemd, runs on every PR) probes
+  the source unit `dist/lorica.service`: `chown` executed under its exact
+  `SystemCallFilter` directives must fail soft (EPERM, exit < 128), not be
+  killed by a signal. Before the fix this probe returns 159 (128 + SIGSYS).
+  This is the PR-time guard, since packaging jobs are gated to main + tags.
+- CI job `test-deb-install` (main + tags only) repeats the probe against
+  the *installed* unit plus `systemd-analyze verify`, catching any
+  packaging drift between `dist/lorica.service` and the shipped unit.
 - The existing `cert_export.rs` unit tests already exercise the
   `EPERM -> PermissionsSkipped` code contract (the test harness has no
   `CAP_CHOWN`, so `chown` returns `EPERM` naturally). No Rust test can

--- a/lorica-api/Cargo.toml
+++ b/lorica-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-api"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -9,11 +9,11 @@ description = "REST API for Lorica reverse proxy management"
 
 [dependencies]
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-config = { version = "1.5.12", path = "../lorica-config" }
-lorica-dashboard = { version = "1.5.12", path = "../lorica-dashboard" }
+lorica-config = { version = "1.5.13", path = "../lorica-config" }
+lorica-dashboard = { version = "1.5.13", path = "../lorica-dashboard" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
-lorica-bench = { version = "1.5.12", path = "../lorica-bench" }
+lorica-bench = { version = "1.5.13", path = "../lorica-bench" }
 # Used in `certificates.rs::validate_certificate_bundle` to gate
 # every cert upload (POST /certificates, PUT /certificates/{id},
 # POST /config/import) with the exact loader the worker uses :

--- a/lorica-api/openapi.yaml
+++ b/lorica-api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lorica API
   description: REST API for Lorica reverse proxy management
-  version: "1.5.12"
+  version: "1.5.13"
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/lorica-bench/Cargo.toml
+++ b/lorica-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-bench"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -8,7 +8,7 @@ repository = "https://github.com/Rwx-G/Lorica"
 description = "SLA monitoring and load testing for Lorica reverse proxy"
 
 [dependencies]
-lorica-config = { version = "1.5.12", path = "../lorica-config" }
+lorica-config = { version = "1.5.13", path = "../lorica-config" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/lorica-challenge/Cargo.toml
+++ b/lorica-challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-challenge"
-version = "1.5.12"
+version = "1.5.13"
 edition = "2021"
 license = "Apache-2.0"
 description = "Bot-protection challenges (cookie + PoW + captcha) for Lorica"

--- a/lorica-command/Cargo.toml
+++ b/lorica-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-command"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-config/Cargo.toml
+++ b/lorica-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-config"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/Cargo.toml
+++ b/lorica-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-dashboard"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-dashboard/frontend/package-lock.json
+++ b/lorica-dashboard/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.5.12",
+      "version": "1.5.13",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/lorica-dashboard/frontend/package.json
+++ b/lorica-dashboard/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.5.12",
+  "version": "1.5.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/lorica-geoip/Cargo.toml
+++ b/lorica-geoip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-geoip"
-version = "1.5.12"
+version = "1.5.13"
 edition = "2021"
 license = "Apache-2.0"
 description = "GeoIP country-code lookup for Lorica, wrapping maxminddb"

--- a/lorica-shmem/Cargo.toml
+++ b/lorica-shmem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-shmem"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica-worker/Cargo.toml
+++ b/lorica-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica-worker"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"

--- a/lorica/Cargo.toml
+++ b/lorica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorica"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Rwx-G"]
 license = "Apache-2.0"
 edition = "2021"
@@ -39,21 +39,21 @@ lorica-lb = { version = "0.1.0", path = "../lorica-lb", optional = true, default
 # call site explicit.
 lorica-ketama = { version = "0.1.0", path = "../lorica-ketama" }
 lorica-proxy = { version = "0.1.0", path = "../lorica-proxy", optional = true, default-features = false }
-lorica-config = { version = "1.5.12", path = "../lorica-config" }
-lorica-api = { version = "1.5.12", path = "../lorica-api" }
+lorica-config = { version = "1.5.13", path = "../lorica-config" }
+lorica-api = { version = "1.5.13", path = "../lorica-api" }
 lorica-error = { version = "0.1.0", path = "../lorica-error" }
 lorica-tls = { version = "0.1.0", path = "../lorica-tls" }
-lorica-worker = { version = "1.5.12", path = "../lorica-worker" }
-lorica-command = { version = "1.5.12", path = "../lorica-command" }
-lorica-shmem = { version = "1.5.12", path = "../lorica-shmem" }
+lorica-worker = { version = "1.5.13", path = "../lorica-worker" }
+lorica-command = { version = "1.5.13", path = "../lorica-command" }
+lorica-shmem = { version = "1.5.13", path = "../lorica-shmem" }
 lorica-waf = { version = "0.1.0", path = "../lorica-waf" }
 lorica-notify = { version = "0.1.0", path = "../lorica-notify" }
 lorica-limits = { version = "0.1.0", path = "../lorica-limits" }
 lorica-cache = { version = "0.1.0", path = "../lorica-cache" }
-lorica-geoip = { version = "1.5.12", path = "../lorica-geoip" }
-lorica-challenge = { version = "1.5.12", path = "../lorica-challenge" }
+lorica-geoip = { version = "1.5.13", path = "../lorica-geoip" }
+lorica-challenge = { version = "1.5.13", path = "../lorica-challenge" }
 once_cell = { workspace = true }
-lorica-bench = { version = "1.5.12", path = "../lorica-bench" }
+lorica-bench = { version = "1.5.13", path = "../lorica-bench" }
 regex = "1"
 # HTML sanitization for operator-supplied error_page_html (v1.5.0
 # audit finding HIGH-1). Whitelist-based parser replaces the


### PR DESCRIPTION
## Summary

Cert-export configured with an owner UID/GID crashed the whole proxy. The
shipped systemd unit denies `@privileged` syscalls with the default
`SECCOMP_RET_KILL` action, and the `chown` family is part of `@privileged`.
When the export applied ownership (`nix::unistd::chown`), the kernel killed
the privileged supervisor process with `SIGSYS`:

```
lorica.service: Main process exited, code=killed, status=31/SYS
```

All workers then lost the command channel and systemd restarted the service.
Certificates renewed or re-exported with an export owner were never written
to disk. The code already degrades gracefully on `EPERM`
(`Err(Errno::EPERM) => Ok(false)` in `cert_export.rs`), but seccomp evaluates
before the capability check, so the kill happened before `EPERM` could return.

## Fix

Downgrade only the `chown` family from kill to a soft `EPERM`, without
granting any capability:

```
SystemCallFilter=~@chown:EPERM
```

Every other `@privileged`/`@resources` syscall still hard-kills. On `EPERM`
the exporter falls back to `ExportOutcome::PermissionsSkipped`: the bundle is
written with the configured file mode (`0640`, owned by `lorica`). Operators
who need the `chown` to take effect must add `CAP_CHOWN` and re-allow `@chown`.

## Proactive syscall audit

Traced every `@privileged`/`@resources` syscall reachable on the runtime
path: `chown` is the only one. Privilege drop is entirely systemd's job
(pre-exec), no `setrlimit`/affinity/`mbind` call sites, shmem uses
`memfd_create`. One latent future risk documented (the no-op `setuid` path in
`lorica-core/src/server/daemon.rs`). Details in
`docs/stories/fix-1.5.13-cert-export-seccomp.md`.

## Regression protection

`test-deb-install` (ubuntu-latest, real systemd) now asserts the softening is
present, runs `systemd-analyze verify`, and executes a syscall-level probe:
`chown` under the unit's exact `SystemCallFilter` directives must fail soft
(EPERM, exit < 128) instead of being killed by SIGSYS (128+31=159 before the
fix). No Rust test can catch this because `cargo test` does not apply the
seccomp filter.

## Testing

- Product crates (`lorica-config`, `lorica-waf`, `lorica-api`, `lorica-notify`,
  `lorica-bench`) green in `rust:1-bookworm`: 119 passed, 0 failed.
- The seccomp behaviour and the new CI steps are validated by this PR's CI run
  (they require Linux + systemd + the built package; not runnable on the
  Windows dev host).

## Hardening review flag

Per `.claude/rules/lorica-systemd.md`, this changes the unit's `SystemCallFilter`
and must be reviewed against the sandbox checklist. The change only softens the
`chown` family to EPERM; it removes no protection, adds no capability, and does
not alter the exposure score for any other syscall.

## Version

Bump `1.5.12 -> 1.5.13` across the pinned files.
