### PR TITLE
fix(ci): the release job produces the SBOM it promises instead of hiding the failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,9 +470,16 @@ jobs:
           path: dist/
 
       - name: Generate SBOM
+        # cargo-cyclonedx writes next to the manifest it describes and has no
+        # output-path flag; `--output-file` was rejected and `|| true` hid it,
+        # so v1.6.0 and v1.7.0 shipped without the SBOM this step promises.
+        # One SBOM for the binary crate covers every workspace dependency.
         run: |
           cargo install cargo-cyclonedx --locked
-          cargo cyclonedx --format json --output-file dist/lorica-sbom.cdx.json || true
+          cargo cyclonedx --format json --spec-version 1.5 \
+            --manifest-path lorica/Cargo.toml --override-filename lorica-sbom
+          mv lorica/lorica-sbom.json dist/lorica-sbom.cdx.json
+          python3 -c "import json; d = json.load(open('dist/lorica-sbom.cdx.json')); assert d['components'], 'empty SBOM'; print(len(d['components']), 'components')"
 
       - name: Create GitHub Release
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Author: Rwx-G
 
 ### Fixed
 
+- The release job now attaches the CycloneDX SBOM it has promised since the SBOM step was added: `cargo cyclonedx` has no `--output-file` flag, the invocation failed on every tag and `|| true` hid it, so the v1.6.0 and v1.7.0 releases carry no SBOM. The step writes `lorica-sbom.cdx.json` (spec 1.5, one document for the `lorica` binary and its 429 dependencies) and fails the job if the document is empty.
 ### Removed
 
 ### Security


### PR DESCRIPTION
fix(ci): the release job produces the SBOM it promises instead of hiding the failure

`cargo cyclonedx` has no `--output-file` flag: the step failed with
"unexpected argument" on every tag and `|| true` hid it, so the v1.6.0
and v1.7.0 releases carry no SBOM. The step now describes the `lorica`
binary crate (`--manifest-path lorica/Cargo.toml`, spec 1.5, 429
components in a local run), moves the document to
`dist/lorica-sbom.cdx.json` and fails the job when it is empty.
Exercised at the next tag.
